### PR TITLE
56 replace variable ast with node

### DIFF
--- a/src/ast/constructor.c
+++ b/src/ast/constructor.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/03 21:24:47 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/05 23:47:54 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:28:08 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,15 +15,15 @@
 
 t_ast	*construct_ast(t_ast_node_type type, t_ast *left, t_ast *right)
 {
-	t_ast	*ast;
+	t_ast	*node;
 
-	ast = ft_xmalloc(sizeof(t_ast));
-	ast->type = type;
-	ast->left = left;
-	ast->right = right;
-	ast->cmd_args = NULL;
-	ast->redirects = NULL;
-	return (ast);
+	node = ft_xmalloc(sizeof(t_ast));
+	node->type = type;
+	node->left = left;
+	node->right = right;
+	node->cmd_args = NULL;
+	node->redirects = NULL;
+	return (node);
 }
 
 t_redirect_info	*construct_redirect_info(t_redirect_type type,

--- a/src/ast/destructor.c
+++ b/src/ast/destructor.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/05 18:58:00 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/05 23:47:54 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:28:38 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,12 +22,12 @@ static void	_destroy_redirect_info(void *content)
 	free(info);
 }
 
-void	destroy_ast(t_ast *ast)
+void	destroy_ast(t_ast *node)
 {
-	if (ast == NULL)
+	if (node == NULL)
 		return ;
-	ft_lstclear(&ast->cmd_args, free);
-	ft_lstclear(&ast->redirects, _destroy_redirect_info);
-	destroy_ast(ast->left);
-	destroy_ast(ast->right);
+	ft_lstclear(&node->cmd_args, free);
+	ft_lstclear(&node->redirects, _destroy_redirect_info);
+	destroy_ast(node->left);
+	destroy_ast(node->right);
 }

--- a/src/ast/push.c
+++ b/src/ast/push.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/05 18:13:36 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/05 23:47:54 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:29:46 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,23 +15,23 @@
 #include "ast.h"
 #include "utils.h"
 
-void	push_cmd_arg(t_ast *ast, const char *arg)
+void	push_cmd_arg(t_ast *node, const char *arg)
 {
-	if (ast->type != AST_COMMAND)
+	if (node->type != AST_COMMAND)
 	{
 		print_error(__func__, "invalid node type");
 		return ;
 	}
-	ft_lstadd_back(&ast->cmd_args, ft_xlstnew(ft_xstrdup(arg)));
+	ft_lstadd_back(&node->cmd_args, ft_xlstnew(ft_xstrdup(arg)));
 }
 
-void	push_redirect_info(t_ast *ast, t_redirect_info *info)
+void	push_redirect_info(t_ast *node, t_redirect_info *info)
 {
-	if (ast->type != AST_COMMAND)
+	if (node->type != AST_COMMAND)
 	{
 		print_error(__func__, "invalid node type");
 		return ;
 	}
-	ft_lstadd_back(&ast->redirects,
+	ft_lstadd_back(&node->redirects,
 		ft_lstnew(construct_redirect_info(info->type, info->filepath)));
 }

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 12:54:34 by yliu              #+#    #+#             */
-/*   Updated: 2024/09/13 17:53:31 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:33:24 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,22 +22,22 @@
 void	exec(char *input, char **envp)
 {
 	t_token_list	*token_list;
-	t_ast			*ast;
+	t_ast			*node;
 	pid_t			last_pid;
 	int				status;
 
 	token_list = lexer(input);
 	if (token_list == NULL)
 		return ;
-	ast = parser(token_list);
-	if (ast == NULL)
+	node = parser(token_list);
+	if (node == NULL)
 	{
 		destroy_token_list(token_list);
 		return ;
 	}
-	if (ast->type == AST_PIPE || ast->type == AST_COMMAND)
+	if (node->type == AST_PIPE || node->type == AST_COMMAND)
 	{
-		last_pid = execute_pipeline(ast, envp, STDIN_FILENO, STDOUT_FILENO);
+		last_pid = execute_pipeline(node, envp, STDIN_FILENO, STDOUT_FILENO);
 		waitpid(last_pid, &status, 0);
 		while (waitpid(-1, NULL, 0) > 0)
 			;
@@ -45,5 +45,5 @@ void	exec(char *input, char **envp)
 	else
 		print_error("exec", "unsupported AST type");
 	destroy_token_list(token_list);
-	destroy_ast(ast);
+	destroy_ast(node);
 }

--- a/src/exec/exec_internal.h
+++ b/src/exec/exec_internal.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 17:46:21 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/14 17:02:28 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:33:41 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 
 # include "libft.h"
 
-pid_t	execute_pipeline(t_ast *ast, char **envp, int fd_in, int fd_out);
+pid_t	execute_pipeline(t_ast *node, char **envp, int fd_in, int fd_out);
 pid_t	execute_simple_command(t_ast *cmd_node, char **envp,
 			int fd_int, int fd_out);
 int		handle_redirects(t_list *redirects);

--- a/src/exec/execute_pipeline.c
+++ b/src/exec/execute_pipeline.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/13 16:15:45 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/14 17:00:42 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:33:50 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,21 +21,21 @@
 #define PIPE_IN 0
 #define PIPE_OUT 1
 
-pid_t	execute_pipeline(t_ast *ast, char **envp, int fd_in, int fd_out)
+pid_t	execute_pipeline(t_ast *node, char **envp, int fd_in, int fd_out)
 {
 	int				pipe_fds[2];
 	pid_t			pid;
 
-	if (ast->type == AST_COMMAND)
-		return (execute_simple_command(ast, envp, fd_in, fd_out));
+	if (node->type == AST_COMMAND)
+		return (execute_simple_command(node, envp, fd_in, fd_out));
 	if (pipe(pipe_fds) == -1)
 	{
 		print_error("pipe", strerror(errno));
 		return (-1);
 	}
-	execute_pipeline(ast->left, envp, fd_in, pipe_fds[PIPE_OUT]);
+	execute_pipeline(node->left, envp, fd_in, pipe_fds[PIPE_OUT]);
 	close(pipe_fds[PIPE_OUT]);
-	pid = execute_pipeline(ast->right, envp, pipe_fds[PIPE_IN], fd_out);
+	pid = execute_pipeline(node->right, envp, pipe_fds[PIPE_IN], fd_out);
 	close(pipe_fds[PIPE_IN]);
 	return (pid);
 }

--- a/src/exec/execute_simple_command.c
+++ b/src/exec/execute_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/13 16:18:33 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/14 17:05:16 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:34:24 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,7 @@ static int	handle_pipeline(int fd_in, int fd_out)
 	return (0);
 }
 
-pid_t	execute_simple_command(t_ast *cmd_node, char **envp,
+pid_t	execute_simple_command(t_ast *node, char **envp,
 			int fd_in, int fd_out)
 {
 	pid_t	pid;
@@ -74,10 +74,10 @@ pid_t	execute_simple_command(t_ast *cmd_node, char **envp,
 	}
 	if (pid == 0)
 	{
-		argv = convert_list_to_array(cmd_node->cmd_args);
+		argv = convert_list_to_array(node->cmd_args);
 		if (handle_pipeline(fd_in, fd_out) == -1)
 			exit(EXIT_FAILURE);
-		if (handle_redirects(cmd_node->redirects) == -1)
+		if (handle_redirects(node->redirects) == -1)
 			exit(EXIT_FAILURE);
 		reset_signal_handlers();
 		if (execve(argv[0], argv, envp) == -1)

--- a/src/parser/parse_pipeline.c
+++ b/src/parser/parse_pipeline.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 22:18:07 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/13 23:51:44 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:31:23 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,18 +21,18 @@
 */
 t_ast	*parse_pipeline(t_token_list **cur_token)
 {
-	t_ast	*ast;
+	t_ast	*node;
 
-	ast = parse_simple_command(cur_token);
-	if (ast == NULL)
+	node = parse_simple_command(cur_token);
+	if (node == NULL)
 		return (NULL);
 	while (get_token_type(*cur_token) != TOKEN_EOF)
 	{
 		if (!expect_token(cur_token, TOKEN_PIPE))
-			return (handle_error(ast, get_token_value(*cur_token)));
+			return (handle_error(node, get_token_value(*cur_token)));
 		if (get_token_type(*cur_token) == TOKEN_EOF)
-			return (handle_error(ast, get_token_value(*cur_token)));
-		ast = construct_ast(AST_PIPE, ast, parse_simple_command(cur_token));
+			return (handle_error(node, get_token_value(*cur_token)));
+		node = construct_ast(AST_PIPE, node, parse_simple_command(cur_token));
 	}
-	return (ast);
+	return (node);
 }

--- a/src/parser/parse_simple_command.c
+++ b/src/parser/parse_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:26:37 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/13 23:51:48 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:31:18 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,13 +25,13 @@ static bool	is_redirect_token(t_token_type type)
 		|| type == TOKEN_DGREAT);
 }
 
-static bool	parse_word(t_ast *ast, t_token_list **cur_token)
+static bool	parse_word(t_ast *node, t_token_list **cur_token)
 {
-	push_cmd_arg(ast, get_token_value(*cur_token));
+	push_cmd_arg(node, get_token_value(*cur_token));
 	return (consume_token(cur_token));
 }
 
-static bool	parse_redirect(t_ast *ast, t_token_list **cur_token)
+static bool	parse_redirect(t_ast *node, t_token_list **cur_token)
 {
 	t_redirect_info	redirect_info;
 	t_token_type	token_type;
@@ -43,7 +43,7 @@ static bool	parse_redirect(t_ast *ast, t_token_list **cur_token)
 	redirect_info.filepath = get_token_value(*cur_token);
 	if (!expect_token(cur_token, TOKEN_WORD))
 		return (false);
-	push_redirect_info(ast, &redirect_info);
+	push_redirect_info(node, &redirect_info);
 	return (true);
 }
 
@@ -57,21 +57,21 @@ static bool	parse_redirect(t_ast *ast, t_token_list **cur_token)
 */
 t_ast	*parse_simple_command(t_token_list **cur_token)
 {
-	t_ast	*ast;
+	t_ast	*node;
 	bool	is_valid;
 
-	ast = construct_ast(AST_COMMAND, NULL, NULL);
+	node = construct_ast(AST_COMMAND, NULL, NULL);
 	is_valid = true;
 	while (get_token_type(*cur_token) != TOKEN_EOF)
 	{
 		if (get_token_type(*cur_token) == TOKEN_WORD)
-			is_valid = parse_word(ast, cur_token);
+			is_valid = parse_word(node, cur_token);
 		else if (is_redirect_token(get_token_type(*cur_token)))
-			is_valid = parse_redirect(ast, cur_token);
+			is_valid = parse_redirect(node, cur_token);
 		else
 			break ;
 		if (!is_valid)
-			return (handle_error(ast, get_token_value(*cur_token)));
+			return (handle_error(node, get_token_value(*cur_token)));
 	}
-	return (ast);
+	return (node);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:11:50 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/13 16:09:46 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:30:55 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,10 +16,10 @@
 
 t_ast	*parser(t_token_list *token_list)
 {
-	t_ast			*ast;
+	t_ast			*node;
 	t_token_list	**cur_token;
 
 	cur_token = &token_list;
-	ast = parse_pipeline(cur_token);
-	return (ast);
+	node = parse_pipeline(cur_token);
+	return (node);
 }

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:22:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/08 18:27:17 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:31:32 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,6 @@ t_ast	*parse_pipeline(t_token_list **cur_token);
 
 bool	consume_token(t_token_list **cur_token);
 bool	expect_token(t_token_list **cur_token, t_token_type type);
-t_ast	*handle_error(t_ast *ast, const char *token_value);
+t_ast	*handle_error(t_ast *node, const char *token_value);
 
 #endif

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:55:24 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/08 18:26:38 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/14 23:31:43 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,11 +33,11 @@ bool	expect_token(t_token_list **cur_token, t_token_type type)
 }
 
 // TODO: Replace newline with the more appropriate token value (EOF?)
-t_ast	*handle_error(t_ast *ast, const char *token_value)
+t_ast	*handle_error(t_ast *node, const char *token_value)
 {
 	if (token_value == NULL)
 		token_value = "newline";
 	print_syntax_error(token_value);
-	destroy_ast(ast);
+	destroy_ast(node);
 	return (NULL);
 }

--- a/tests/unit/test_ast.cpp
+++ b/tests/unit/test_ast.cpp
@@ -7,89 +7,89 @@ extern "C" {
 }
 
 TEST(construct_ast, OneNode) {
-  t_ast *ast = construct_ast(AST_COMMAND, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_COMMAND, nullptr, nullptr);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_EQ(ast->left, nullptr);
-  EXPECT_EQ(ast->right, nullptr);
-  EXPECT_EQ(ast->cmd_args, nullptr);
-  EXPECT_EQ(ast->redirects, nullptr);
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_EQ(node->left, nullptr);
+  EXPECT_EQ(node->right, nullptr);
+  EXPECT_EQ(node->cmd_args, nullptr);
+  EXPECT_EQ(node->redirects, nullptr);
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(construct_ast, MultipleNodes) {
   t_ast *left = construct_ast(AST_COMMAND, nullptr, nullptr);
   t_ast *right = construct_ast(AST_COMMAND, nullptr, nullptr);
-  t_ast *ast = construct_ast(AST_PIPE, left, right);
+  t_ast *node = construct_ast(AST_PIPE, left, right);
 
-  EXPECT_EQ(ast->type, AST_PIPE);
-  EXPECT_EQ(ast->left, left);
-  EXPECT_EQ(ast->right, right);
-  EXPECT_EQ(ast->cmd_args, nullptr);
-  EXPECT_EQ(ast->redirects, nullptr);
+  EXPECT_EQ(node->type, AST_PIPE);
+  EXPECT_EQ(node->left, left);
+  EXPECT_EQ(node->right, right);
+  EXPECT_EQ(node->cmd_args, nullptr);
+  EXPECT_EQ(node->redirects, nullptr);
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(push_cmd_arg, OneArg) {
-  t_ast *ast = construct_ast(AST_COMMAND, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_COMMAND, nullptr, nullptr);
 
-  push_cmd_arg(ast, "ls");
+  push_cmd_arg(node, "ls");
 
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(push_cmd_arg, MultipleArgs) {
-  t_ast *ast = construct_ast(AST_COMMAND, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_COMMAND, nullptr, nullptr);
 
-  push_cmd_arg(ast, "ls");
-  push_cmd_arg(ast, "-l");
-  push_cmd_arg(ast, "-a");
+  push_cmd_arg(node, "ls");
+  push_cmd_arg(node, "-l");
+  push_cmd_arg(node, "-a");
 
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-l");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next->next), "-a");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-l");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next->next), "-a");
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(push_redirect_info, OneRedirect) {
-  t_ast *ast = construct_ast(AST_COMMAND, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_COMMAND, nullptr, nullptr);
   t_redirect_info *info = construct_redirect_info(REDIRECT_INPUT, "input.txt");
 
-  push_redirect_info(ast, info);
+  push_redirect_info(node, info);
 
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "input.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_INPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "input.txt");
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(push_redirect_info, MultipleRedirects) {
-  t_ast *ast = construct_ast(AST_COMMAND, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_COMMAND, nullptr, nullptr);
   t_redirect_info *info_1 =
       construct_redirect_info(REDIRECT_INPUT, "input.txt");
   t_redirect_info *info_2 =
       construct_redirect_info(REDIRECT_OUTPUT, "output.txt");
 
-  push_redirect_info(ast, info_1);
-  push_redirect_info(ast, info_2);
+  push_redirect_info(node, info_1);
+  push_redirect_info(node, info_2);
 
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "input.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next), "output.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_INPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "input.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next), "output.txt");
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(construct_ast, ComplexNodes) {
   t_ast *left = construct_ast(AST_COMMAND, nullptr, nullptr);
   t_ast *right = construct_ast(AST_COMMAND, nullptr, nullptr);
-  t_ast *ast = construct_ast(AST_PIPE, left, right);
+  t_ast *node = construct_ast(AST_PIPE, left, right);
 
   push_cmd_arg(left, "ls");
   push_cmd_arg(left, "-l");
@@ -105,9 +105,9 @@ TEST(construct_ast, ComplexNodes) {
   push_redirect_info(left, info_1);
   push_redirect_info(right, info_2);
 
-  EXPECT_EQ(ast->type, AST_PIPE);
-  EXPECT_EQ(ast->left, left);
-  EXPECT_EQ(ast->right, right);
+  EXPECT_EQ(node->type, AST_PIPE);
+  EXPECT_EQ(node->left, left);
+  EXPECT_EQ(node->right, right);
 
   EXPECT_STREQ(get_cmd_arg(left->cmd_args), "ls");
   EXPECT_STREQ(get_cmd_arg(left->cmd_args->next), "-l");
@@ -120,7 +120,7 @@ TEST(construct_ast, ComplexNodes) {
   EXPECT_EQ(get_redirect_type(right->redirects), REDIRECT_OUTPUT);
   EXPECT_STREQ(get_redirect_filepath(right->redirects), "output.txt");
 
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(get_cmd_arg, NullCmdArgs) {
@@ -142,16 +142,16 @@ TEST(get_redirect_filepath, NullRedirects) {
 }
 
 TEST(push_cmd_arg, InvalidNodeType) {
-  t_ast *ast = construct_ast(AST_PIPE, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_PIPE, nullptr, nullptr);
 
-  push_cmd_arg(ast, "ls");
-  EXPECT_EQ(ast->cmd_args, nullptr);
+  push_cmd_arg(node, "ls");
+  EXPECT_EQ(node->cmd_args, nullptr);
 }
 
 TEST(push_redirect_info, InvalidNodeType) {
-  t_ast *ast = construct_ast(AST_PIPE, nullptr, nullptr);
+  t_ast *node = construct_ast(AST_PIPE, nullptr, nullptr);
   t_redirect_info *info = construct_redirect_info(REDIRECT_INPUT, "input.txt");
 
-  push_redirect_info(ast, info);
-  EXPECT_EQ(ast->redirects, nullptr);
+  push_redirect_info(node, info);
+  EXPECT_EQ(node->redirects, nullptr);
 }

--- a/tests/unit/test_parse_pipeline.cpp
+++ b/tests/unit/test_parse_pipeline.cpp
@@ -18,14 +18,14 @@ TEST(parse_pipeline, SimpleCommand) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_pipeline(&token_list);
+  t_ast *node = parse_pipeline(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-l");
-  EXPECT_EQ(ast->redirects, nullptr);
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-l");
+  EXPECT_EQ(node->redirects, nullptr);
 
-  destroy_ast(ast);
+  destroy_ast(node);
   destroy_token_list(token_list);
 }
 
@@ -39,18 +39,18 @@ TEST(parse_pipeline, OnePipeline) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("wc")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_pipeline(&token_list);
+  t_ast *node = parse_pipeline(&token_list);
 
-  EXPECT_EQ(ast->type, AST_PIPE);
-  EXPECT_EQ(ast->left->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->left->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->left->cmd_args->next), "-l");
-  EXPECT_EQ(ast->left->redirects, nullptr);
-  EXPECT_EQ(ast->right->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->right->cmd_args), "wc");
-  EXPECT_EQ(ast->right->redirects, nullptr);
+  EXPECT_EQ(node->type, AST_PIPE);
+  EXPECT_EQ(node->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args->next), "-l");
+  EXPECT_EQ(node->left->redirects, nullptr);
+  EXPECT_EQ(node->right->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->right->cmd_args), "wc");
+  EXPECT_EQ(node->right->redirects, nullptr);
 
-  destroy_ast(ast);
+  destroy_ast(node);
   destroy_token_list(token_list);
 }
 
@@ -74,25 +74,25 @@ TEST(parse_pipeline, MultiplePipelines) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-e")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_pipeline(&token_list);
+  t_ast *node = parse_pipeline(&token_list);
 
-  EXPECT_EQ(ast->type, AST_PIPE);
+  EXPECT_EQ(node->type, AST_PIPE);
 
-  EXPECT_EQ(ast->left->type, AST_PIPE);
-  EXPECT_EQ(ast->right->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->right->cmd_args), "cat");
-  EXPECT_STREQ(get_cmd_arg(ast->right->cmd_args->next), "-e");
-  EXPECT_STREQ(get_cmd_arg(ast->right->cmd_args->next->next), nullptr);
+  EXPECT_EQ(node->left->type, AST_PIPE);
+  EXPECT_EQ(node->right->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->right->cmd_args), "cat");
+  EXPECT_STREQ(get_cmd_arg(node->right->cmd_args->next), "-e");
+  EXPECT_STREQ(get_cmd_arg(node->right->cmd_args->next->next), nullptr);
 
-  EXPECT_EQ(ast->left->left->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->left->left->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->left->left->cmd_args->next), "-l");
-  EXPECT_STREQ(get_cmd_arg(ast->left->left->cmd_args->next->next), nullptr);
-  EXPECT_EQ(ast->left->right->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->left->right->cmd_args), "wc");
-  EXPECT_STREQ(get_cmd_arg(ast->left->right->cmd_args->next), nullptr);
+  EXPECT_EQ(node->left->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args->next), "-l");
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args->next->next), nullptr);
+  EXPECT_EQ(node->left->right->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->right->cmd_args), "wc");
+  EXPECT_STREQ(get_cmd_arg(node->left->right->cmd_args->next), nullptr);
 
-  destroy_ast(ast);
+  destroy_ast(node);
   destroy_token_list(token_list);
 }
 
@@ -105,9 +105,9 @@ TEST(parse_pipeline, InvalidToken) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_PIPE, strdup("|")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_pipeline(&token_list);
+  t_ast *node = parse_pipeline(&token_list);
 
-  EXPECT_EQ(ast, nullptr);
+  EXPECT_EQ(node, nullptr);
 
   destroy_token_list(token_list);
 }

--- a/tests/unit/test_parse_simple_command.cpp
+++ b/tests/unit/test_parse_simple_command.cpp
@@ -15,14 +15,14 @@ TEST(parse_simple_command, OneCommand) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args->next), nullptr);
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_EQ(get_cmd_arg(node->cmd_args->next), nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, MultipleCommands) {
@@ -33,17 +33,17 @@ TEST(parse_simple_command, MultipleCommands) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("src")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
   // ls -l src
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-l");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next->next), "src");
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args->next->next->next), nullptr);
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-l");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next->next), "src");
+  EXPECT_EQ(get_cmd_arg(node->cmd_args->next->next->next), nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, OneRedirect) {
@@ -54,15 +54,15 @@ TEST(parse_simple_command, OneRedirect) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls.txt")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args), nullptr);
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "ls.txt");
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_EQ(get_cmd_arg(node->cmd_args), nullptr);
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "ls.txt");
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, MultipleRedirects) {
@@ -81,31 +81,31 @@ TEST(parse_simple_command, MultipleRedirects) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out3.txt")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args), nullptr);
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "in1.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next), "out1.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next), REDIRECT_APPEND);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next->next), "out2.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next->next),
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_EQ(get_cmd_arg(node->cmd_args), nullptr);
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_INPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "in1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next), "out1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next), REDIRECT_APPEND);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next->next), "out2.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next->next),
             REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next->next->next),
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next->next->next),
                "in2.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next->next->next),
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next->next->next),
             REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next->next->next->next),
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next->next->next->next),
                "out3.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next->next->next->next),
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next->next->next->next),
             REDIRECT_UNKNOWN);
-  EXPECT_EQ(get_redirect_filepath(ast->redirects->next->next->next->next->next),
+  EXPECT_EQ(get_redirect_filepath(node->redirects->next->next->next->next->next),
             nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, CommandAndRedirect) {
@@ -118,19 +118,19 @@ TEST(parse_simple_command, CommandAndRedirect) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out.txt")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-l");
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args->next->next), nullptr);
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "out.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next), REDIRECT_UNKNOWN);
-  EXPECT_EQ(get_redirect_filepath(ast->redirects->next), nullptr);
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-l");
+  EXPECT_EQ(get_cmd_arg(node->cmd_args->next->next), nullptr);
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "out.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_UNKNOWN);
+  EXPECT_EQ(get_redirect_filepath(node->redirects->next), nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, RedirectsAfterCommand) {
@@ -147,24 +147,24 @@ TEST(parse_simple_command, RedirectsAfterCommand) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out3.txt")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "ls");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-l");
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args->next->next), nullptr);
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "out1.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next), REDIRECT_APPEND);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next), "out2.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next->next), "out3.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next->next),
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-l");
+  EXPECT_EQ(get_cmd_arg(node->cmd_args->next->next), nullptr);
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "out1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_APPEND);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next), "out2.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next->next), "out3.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next->next),
             REDIRECT_UNKNOWN);
-  EXPECT_EQ(get_redirect_filepath(ast->redirects->next->next->next), nullptr);
+  EXPECT_EQ(get_redirect_filepath(node->redirects->next->next->next), nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, RedirectsBeforeCommand) {
@@ -181,24 +181,24 @@ TEST(parse_simple_command, RedirectsBeforeCommand) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-e")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "cat");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-e");
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args->next->next), nullptr);
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "in1.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next), "out.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next), REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next->next), "in2.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next->next),
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "cat");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-e");
+  EXPECT_EQ(get_cmd_arg(node->cmd_args->next->next), nullptr);
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_INPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "in1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next), "out.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next), REDIRECT_INPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next->next), "in2.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next->next),
             REDIRECT_UNKNOWN);
-  EXPECT_EQ(get_redirect_filepath(ast->redirects->next->next->next), nullptr);
+  EXPECT_EQ(get_redirect_filepath(node->redirects->next->next->next), nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, RedirectsBeforeAndAfterCommand) {
@@ -215,24 +215,24 @@ TEST(parse_simple_command, RedirectsBeforeAndAfterCommand) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out2.txt")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast->type, AST_COMMAND);
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args), "cat");
-  EXPECT_STREQ(get_cmd_arg(ast->cmd_args->next), "-e");
-  EXPECT_EQ(get_cmd_arg(ast->cmd_args->next->next), nullptr);
-  EXPECT_EQ(get_redirect_type(ast->redirects), REDIRECT_INPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects), "in1.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next), "out1.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next), REDIRECT_OUTPUT);
-  EXPECT_STREQ(get_redirect_filepath(ast->redirects->next->next), "out2.txt");
-  EXPECT_EQ(get_redirect_type(ast->redirects->next->next->next),
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "cat");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-e");
+  EXPECT_EQ(get_cmd_arg(node->cmd_args->next->next), nullptr);
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_INPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "in1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next), "out1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next->next), "out2.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next->next->next),
             REDIRECT_UNKNOWN);
-  EXPECT_EQ(get_redirect_filepath(ast->redirects->next->next->next), nullptr);
+  EXPECT_EQ(get_redirect_filepath(node->redirects->next->next->next), nullptr);
 
   destroy_token_list(token_list);
-  destroy_ast(ast);
+  destroy_ast(node);
 }
 
 TEST(parse_simple_command, InvalidRedirect) {
@@ -245,9 +245,9 @@ TEST(parse_simple_command, InvalidRedirect) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast, nullptr);
+  EXPECT_EQ(node, nullptr);
 }
 
 TEST(parse_simple_command, InvalidRedirect2) {
@@ -261,7 +261,7 @@ TEST(parse_simple_command, InvalidRedirect2) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_LESS, strdup("<")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  t_ast *ast = parse_simple_command(&token_list);
+  t_ast *node = parse_simple_command(&token_list);
 
-  EXPECT_EQ(ast, nullptr);
+  EXPECT_EQ(node, nullptr);
 }


### PR DESCRIPTION
fix #56

- **Replace ast with node in ast**
- **Replace ast with node in parser**
- **Replace ast with node in exec**
- **Replace ast with node in tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed variables from `ast` to `node` across multiple functions to enhance clarity and readability without affecting functionality.
  
- **Tests**
	- Updated test cases to reflect the variable name changes from `ast` to `node`, maintaining the same test logic and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->