### PR TITLE
64 implement parse command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ SRC				= $(SRC_DIR)/main.c \
 					$(SRC_DIR)/lexer/process_eof.c \
 					$(SRC_DIR)/lexer/process_operator.c \
 					$(SRC_DIR)/lexer/process_quote.c \
+					$(SRC_DIR)/parser/parse_command.c \
 					$(SRC_DIR)/parser/parse_list.c \
 					$(SRC_DIR)/parser/parse_simple_command.c \
 					$(SRC_DIR)/parser/parse_redirect.c \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ SRC				= $(SRC_DIR)/main.c \
 					$(SRC_DIR)/lexer/process_quote.c \
 					$(SRC_DIR)/parser/parse_list.c \
 					$(SRC_DIR)/parser/parse_simple_command.c \
+					$(SRC_DIR)/parser/parse_redirect.c \
 					$(SRC_DIR)/parser/parse_pipeline.c \
 					$(SRC_DIR)/parser/parser_utils.c \
 					$(SRC_DIR)/parser/parser.c \

--- a/docs/grammer.md
+++ b/docs/grammer.md
@@ -16,8 +16,12 @@ list             :           pipeline
                  | list '&&' pipeline
                  | list '||' pipeline
                  ;
-pipeline         :              simple_command
-                 | pipeline '|' simple_command
+pipeline         :              command
+                 | pipeline '|' command
+                 ;
+command          : simple_command
+                 | '(' list ')'
+                 | '(' list ')' redirect_list
                  ;
 simple_command   : cmd_prefix cmd_word cmd_suffix
                  | cmd_prefix cmd_word

--- a/include/ast.h
+++ b/include/ast.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/03 20:41:56 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/14 21:04:57 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 13:44:20 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,12 +18,11 @@
 
 typedef enum e_ast_node_type
 {
+	AST_AND = TOKEN_AND_IF,
+	AST_OR = TOKEN_OR_IF,
 	AST_COMMAND,
 	AST_PIPE,
-	AST_AND,
-	AST_OR,
 	AST_SUBSHELL,
-	AST_REDIRECT,
 	AST_UNKNOWN,
 }					t_ast_node_type;
 

--- a/src/ast/push.c
+++ b/src/ast/push.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/05 18:13:36 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/14 23:29:46 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 19:15:26 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ void	push_cmd_arg(t_ast *node, const char *arg)
 
 void	push_redirect_info(t_ast *node, t_redirect_info *info)
 {
-	if (node->type != AST_COMMAND)
+	if (node->type != AST_COMMAND && node->type != AST_SUBSHELL)
 	{
 		print_error(__func__, "invalid node type");
 		return ;

--- a/src/parser/parse_command.c
+++ b/src/parser/parse_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 02:19:16 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 19:15:48 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:41:12 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,11 +33,11 @@ t_ast	*parse_command(t_token_list **cur_token)
 		return (NULL);
 	node = construct_ast(AST_SUBSHELL, tmp, NULL);
 	if (!expect_token(cur_token, TOKEN_R_PARENTHESIS))
-		return (handle_error(node, get_token_value(*cur_token)));
+		return (handle_syntax_error(node, get_token_value(*cur_token)));
 	while (is_redirect_token(get_token_type(*cur_token)))
 	{
 		if (!parse_redirect(node, cur_token))
-			return (handle_error(node, get_token_value(*cur_token)));
+			return (handle_syntax_error(node, get_token_value(*cur_token)));
 	}
 	return (node);
 }

--- a/src/parser/parse_command.c
+++ b/src/parser/parse_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 02:19:16 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 02:28:48 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 19:15:48 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,16 +23,18 @@
 t_ast	*parse_command(t_token_list **cur_token)
 {
 	t_ast	*node;
+	t_ast	*tmp;
 
 	if (get_token_type(*cur_token) != TOKEN_L_PARENTHESIS)
 		return (parse_simple_command(cur_token));
 	consume_token(cur_token);
-	node = parse_list(cur_token);
-	if (node == NULL)
+	tmp = parse_list(cur_token);
+	if (tmp == NULL)
 		return (NULL);
+	node = construct_ast(AST_SUBSHELL, tmp, NULL);
 	if (!expect_token(cur_token, TOKEN_R_PARENTHESIS))
 		return (handle_error(node, get_token_value(*cur_token)));
-	if (is_redirect_token(get_token_type(*cur_token)))
+	while (is_redirect_token(get_token_type(*cur_token)))
 	{
 		if (!parse_redirect(node, cur_token))
 			return (handle_error(node, get_token_value(*cur_token)));

--- a/src/parser/parse_command.c
+++ b/src/parser/parse_command.c
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_command.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/17 02:19:16 by reasuke           #+#    #+#             */
+/*   Updated: 2024/09/17 02:28:48 by reasuke          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ast.h"
+#include "parser_internal.h"
+#include "token.h"
+
+/*
+** command  : simple_command
+**          : '(' list ')'
+**          : '(' list ')' redirect_list
+**          ;
+*/
+t_ast	*parse_command(t_token_list **cur_token)
+{
+	t_ast	*node;
+
+	if (get_token_type(*cur_token) != TOKEN_L_PARENTHESIS)
+		return (parse_simple_command(cur_token));
+	consume_token(cur_token);
+	node = parse_list(cur_token);
+	if (node == NULL)
+		return (NULL);
+	if (!expect_token(cur_token, TOKEN_R_PARENTHESIS))
+		return (handle_error(node, get_token_value(*cur_token)));
+	if (is_redirect_token(get_token_type(*cur_token)))
+	{
+		if (!parse_redirect(node, cur_token))
+			return (handle_error(node, get_token_value(*cur_token)));
+	}
+	return (node);
+}

--- a/src/parser/parse_list.c
+++ b/src/parser/parse_list.c
@@ -6,22 +6,13 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/14 20:48:52 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 02:50:44 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 13:47:18 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ast.h"
 #include "parser_internal.h"
 #include "token.h"
-
-static t_ast_node_type	convert_token_to_node(t_token_type token_type)
-{
-	if (token_type == TOKEN_AND_IF)
-		return (AST_AND);
-	else if (token_type == TOKEN_OR_IF)
-		return (AST_OR);
-	return (AST_UNKNOWN);
-}
 
 /*
 ** list  :           pipeline
@@ -40,7 +31,7 @@ t_ast	*parse_list(t_token_list **cur_token)
 		return (NULL);
 	while (get_token_type(*cur_token) != TOKEN_EOF)
 	{
-		node_type = convert_token_to_node(get_token_type(*cur_token));
+		node_type = (t_ast_node_type)get_token_type(*cur_token);
 		if (node_type != AST_AND && node_type != AST_OR)
 			break ;
 		consume_token(cur_token);

--- a/src/parser/parse_list.c
+++ b/src/parser/parse_list.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/14 20:48:52 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/16 23:54:54 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 02:50:44 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ t_ast	*parse_list(t_token_list **cur_token)
 	{
 		node_type = convert_token_to_node(get_token_type(*cur_token));
 		if (node_type != AST_AND && node_type != AST_OR)
-			return (handle_error(node, get_token_value(*cur_token)));
+			break ;
 		consume_token(cur_token);
 		tmp = parse_pipeline(cur_token);
 		if (tmp == NULL)

--- a/src/parser/parse_pipeline.c
+++ b/src/parser/parse_pipeline.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/07 22:18:07 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/16 23:51:01 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 02:40:07 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 #include "token.h"
 
 /*
-** pipeline  :              simple_command
-**           | pipeline '|' simple_command
+** pipeline  :              command
+**           : pipeline '|' command
 **           ;
 */
 t_ast	*parse_pipeline(t_token_list **cur_token)
@@ -24,7 +24,7 @@ t_ast	*parse_pipeline(t_token_list **cur_token)
 	t_ast	*node;
 	t_ast	*tmp;
 
-	node = parse_simple_command(cur_token);
+	node = parse_command(cur_token);
 	if (node == NULL)
 		return (NULL);
 	while (get_token_type(*cur_token) != TOKEN_EOF)
@@ -32,7 +32,7 @@ t_ast	*parse_pipeline(t_token_list **cur_token)
 		if (get_token_type(*cur_token) != TOKEN_PIPE)
 			break ;
 		consume_token(cur_token);
-		tmp = parse_simple_command(cur_token);
+		tmp = parse_command(cur_token);
 		if (tmp == NULL)
 			return (NULL);
 		node = construct_ast(AST_PIPE, node, tmp);

--- a/src/parser/parse_redirect.c
+++ b/src/parser/parse_redirect.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_redirect.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/17 02:28:39 by reasuke           #+#    #+#             */
+/*   Updated: 2024/09/17 02:31:10 by reasuke          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ast.h"
+#include "parser_internal.h"
+#include "token.h"
+
+bool	is_redirect_token(t_token_type type)
+{
+	return (type == TOKEN_LESS
+		|| type == TOKEN_GREAT
+		|| type == TOKEN_DLESS
+		|| type == TOKEN_DGREAT);
+}
+
+bool	parse_redirect(t_ast *node, t_token_list **cur_token)
+{
+	t_redirect_info	redirect_info;
+	t_token_type	token_type;
+
+	token_type = get_token_type(*cur_token);
+	redirect_info.type = (t_redirect_type)token_type;
+	if (!expect_token(cur_token, token_type))
+		return (false);
+	redirect_info.filepath = get_token_value(*cur_token);
+	if (!expect_token(cur_token, TOKEN_WORD))
+		return (false);
+	push_redirect_info(node, &redirect_info);
+	return (true);
+}

--- a/src/parser/parse_simple_command.c
+++ b/src/parser/parse_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:26:37 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 02:33:21 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:41:12 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ t_ast	*parse_simple_command(t_token_list **cur_token)
 	t_parse_simple_commnad	parse_func;
 
 	if (!is_valid_head_token_simple_command(cur_token))
-		return (handle_error(NULL, get_token_value(*cur_token)));
+		return (handle_syntax_error(NULL, get_token_value(*cur_token)));
 	node = construct_ast(AST_COMMAND, NULL, NULL);
 	while (get_token_type(*cur_token) != TOKEN_EOF)
 	{
@@ -54,7 +54,7 @@ t_ast	*parse_simple_command(t_token_list **cur_token)
 		else
 			break ;
 		if (!parse_func(node, cur_token))
-			return (handle_error(node, get_token_value(*cur_token)));
+			return (handle_syntax_error(node, get_token_value(*cur_token)));
 	}
 	return (node);
 }

--- a/src/parser/parse_simple_command.c
+++ b/src/parser/parse_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:26:37 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 00:16:17 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 02:33:21 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,40 +17,16 @@
 #include "token.h"
 #include "utils.h"
 
-static bool	is_redirect_token(t_token_type type)
-{
-	return (type == TOKEN_LESS
-		|| type == TOKEN_GREAT
-		|| type == TOKEN_DLESS
-		|| type == TOKEN_DGREAT);
-}
-
 static bool	is_valid_head_token_simple_command(t_token_list **cur_token)
 {
 	return (get_token_type(*cur_token) == TOKEN_WORD
 		|| is_redirect_token(get_token_type(*cur_token)));
 }
 
-static bool	parse_word(t_ast *node, t_token_list **cur_token)
+static bool	parse_cmd_arg(t_ast *node, t_token_list **cur_token)
 {
 	push_cmd_arg(node, get_token_value(*cur_token));
 	return (consume_token(cur_token));
-}
-
-static bool	parse_redirect(t_ast *node, t_token_list **cur_token)
-{
-	t_redirect_info	redirect_info;
-	t_token_type	token_type;
-
-	token_type = get_token_type(*cur_token);
-	redirect_info.type = (t_redirect_type)token_type;
-	if (!expect_token(cur_token, token_type))
-		return (false);
-	redirect_info.filepath = get_token_value(*cur_token);
-	if (!expect_token(cur_token, TOKEN_WORD))
-		return (false);
-	push_redirect_info(node, &redirect_info);
-	return (true);
 }
 
 /*
@@ -72,7 +48,7 @@ t_ast	*parse_simple_command(t_token_list **cur_token)
 	while (get_token_type(*cur_token) != TOKEN_EOF)
 	{
 		if (get_token_type(*cur_token) == TOKEN_WORD)
-			parse_func = parse_word;
+			parse_func = parse_cmd_arg;
 		else if (is_redirect_token(get_token_type(*cur_token)))
 			parse_func = parse_redirect;
 		else

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:22:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 02:33:59 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:41:12 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,6 @@ bool	is_redirect_token(t_token_type type);
 
 bool	consume_token(t_token_list **cur_token);
 bool	expect_token(t_token_list **cur_token, t_token_type type);
-t_ast	*handle_error(t_ast *node, const char *token_value);
+t_ast	*handle_syntax_error(t_ast *node, const char *token_value);
 
 #endif

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:22:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 00:12:53 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 02:31:46 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,8 @@ typedef bool	(*t_parse_simple_commnad)(t_ast *node, t_token_list **token);
 t_ast	*parse_simple_command(t_token_list **cur_token);
 t_ast	*parse_pipeline(t_token_list **cur_token);
 t_ast	*parse_list(t_token_list **cur_token);
+bool	parse_redirect(t_ast *node, t_token_list **cur_token);
+bool	is_redirect_token(t_token_type type);
 
 bool	consume_token(t_token_list **cur_token);
 bool	expect_token(t_token_list **cur_token, t_token_type type);

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:22:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/17 02:31:46 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/17 02:33:59 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ typedef bool	(*t_parse_simple_commnad)(t_ast *node, t_token_list **token);
 
 t_ast	*parse_simple_command(t_token_list **cur_token);
 t_ast	*parse_pipeline(t_token_list **cur_token);
+t_ast	*parse_command(t_token_list **cur_token);
 t_ast	*parse_list(t_token_list **cur_token);
 bool	parse_redirect(t_ast *node, t_token_list **cur_token);
 bool	is_redirect_token(t_token_type type);

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:55:24 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/18 00:41:33 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:42:22 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,11 +32,10 @@ bool	expect_token(t_token_list **cur_token, t_token_type type)
 	return (true);
 }
 
-// TODO: Replace newline with the more appropriate token value (EOF?)
 t_ast	*handle_syntax_error(t_ast *node, const char *token_value)
 {
 	if (token_value == NULL)
-		token_value = "newline";
+		token_value = "EOF";
 	print_syntax_error(token_value);
 	destroy_ast(node);
 	return (NULL);

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 19:55:24 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/14 23:31:43 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:41:33 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ bool	expect_token(t_token_list **cur_token, t_token_type type)
 }
 
 // TODO: Replace newline with the more appropriate token value (EOF?)
-t_ast	*handle_error(t_ast *node, const char *token_value)
+t_ast	*handle_syntax_error(t_ast *node, const char *token_value)
 {
 	if (token_value == NULL)
 		token_value = "newline";

--- a/src/utils/print_error.c
+++ b/src/utils/print_error.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/01 22:20:54 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/18 00:44:02 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:47:46 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,8 @@ void	print_syntax_error(const char *token_value)
 		close(stdout_fd);
 		return ;
 	}
-	res = printf("minishell: syntax error near unexpected token `%s'\n", token_value);
+	res = printf("minishell: syntax error near unexpected token `%s'\n",
+			token_value);
 	if (res < 0)
 		perror("minishell: printf");
 	if (dup2(stdout_fd, STDOUT_FILENO) == -1)

--- a/src/utils/print_error.c
+++ b/src/utils/print_error.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/01 22:20:54 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/07 15:33:43 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/09/18 00:44:02 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,7 @@ void	print_syntax_error(const char *token_value)
 		close(stdout_fd);
 		return ;
 	}
-	res = printf("minishell: unexpected token near `%s'\n", token_value);
+	res = printf("minishell: syntax error near unexpected token `%s'\n", token_value);
 	if (res < 0)
 		perror("minishell: printf");
 	if (dup2(stdout_fd, STDOUT_FILENO) == -1)

--- a/tests/unit/test_parse_command.cpp
+++ b/tests/unit/test_parse_command.cpp
@@ -198,11 +198,13 @@ TEST(parse_command, UnclosedParenthesis) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_AND_IF, strdup("&&")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
+  std::cerr << std::flush;
   ::testing::internal::CaptureStderr();
 
   t_ast *node = parse_command(&token_list);
 
   std::string err_msg = ::testing::internal::GetCapturedStderr();
+  std::cerr << std::flush;
 
   EXPECT_EQ(node, nullptr);
   EXPECT_STRCASEEQ(err_msg.c_str(),
@@ -224,11 +226,13 @@ TEST(parse_command, InvalidTokenPipe) {
                  construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
+  std::cerr << std::flush;
   ::testing::internal::CaptureStderr();
 
   t_ast *node = parse_command(&token_list);
 
   std::string err_msg = ::testing::internal::GetCapturedStderr();
+  std::cerr << std::flush;
 
   EXPECT_EQ(node, nullptr);
   EXPECT_STRCASEEQ(err_msg.c_str(), "minishell: unexpected token near `)'\n");
@@ -249,11 +253,13 @@ TEST(parse_command, InvalidTokenRedirect) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
+  std::cerr << std::flush;
   ::testing::internal::CaptureStderr();
 
   t_ast *node = parse_command(&token_list);
 
   std::string err_msg = ::testing::internal::GetCapturedStderr();
+  std::cerr << std::flush;
 
   EXPECT_EQ(node, nullptr);
   EXPECT_STRCASEEQ(err_msg.c_str(),

--- a/tests/unit/test_parse_command.cpp
+++ b/tests/unit/test_parse_command.cpp
@@ -198,17 +198,9 @@ TEST(parse_command, UnclosedParenthesis) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_AND_IF, strdup("&&")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  std::cerr << std::flush;
-  ::testing::internal::CaptureStderr();
-
   t_ast *node = parse_command(&token_list);
 
-  std::string err_msg = ::testing::internal::GetCapturedStderr();
-  std::cerr << std::flush;
-
   EXPECT_EQ(node, nullptr);
-  EXPECT_STREQ(err_msg.c_str(),
-                   "minishell: unexpected token near `newline'\n");
 
   destroy_token_list(token_list);
 }
@@ -226,16 +218,9 @@ TEST(parse_command, InvalidTokenPipe) {
                  construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  std::cerr << std::flush;
-  ::testing::internal::CaptureStderr();
-
   t_ast *node = parse_command(&token_list);
 
-  std::string err_msg = ::testing::internal::GetCapturedStderr();
-  std::cerr << std::flush;
-
   EXPECT_EQ(node, nullptr);
-  EXPECT_STREQ(err_msg.c_str(), "minishell: unexpected token near `)'\n");
 
   destroy_token_list(token_list);
 }
@@ -253,17 +238,9 @@ TEST(parse_command, InvalidTokenRedirect) {
   ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 
-  std::cerr << std::flush;
-  ::testing::internal::CaptureStderr();
-
   t_ast *node = parse_command(&token_list);
 
-  std::string err_msg = ::testing::internal::GetCapturedStderr();
-  std::cerr << std::flush;
-
   EXPECT_EQ(node, nullptr);
-  EXPECT_STREQ(err_msg.c_str(),
-                   "minishell: unexpected token near `newline'\n");
 
   destroy_token_list(token_list);
 }

--- a/tests/unit/test_parse_command.cpp
+++ b/tests/unit/test_parse_command.cpp
@@ -1,0 +1,263 @@
+// Copyright 2024, reasuke
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "ast.h"
+#include "parser/parser_internal.h"
+#include "token.h"
+}
+
+TEST(parse_command, SimpleCommand) {
+  t_token_list *token_list = nullptr;
+
+  // ls -l
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  t_ast *node = parse_command(&token_list);
+
+  EXPECT_EQ(node->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->cmd_args->next), "-l");
+  EXPECT_EQ(node->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->redirects, nullptr);
+
+  destroy_ast(node);
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, OneSubshell) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l)
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  t_ast *node = parse_command(&token_list);
+
+  /*
+  **  SUBSHELL
+  **     |
+  **  COMMAND(ls -l)
+  */
+  EXPECT_EQ(node->type, AST_SUBSHELL);
+  EXPECT_EQ(node->redirects, nullptr);
+
+  EXPECT_EQ(node->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args->next), "-l");
+  EXPECT_EQ(node->left->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->left->redirects, nullptr);
+
+  destroy_ast(node);
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, OneSubshellWithOneRedirect) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l) > out.txt
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out.txt")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  t_ast *node = parse_command(&token_list);
+
+  /*
+  **  SUBSHELL(> out.txt)
+  **     |
+  **  COMMAND(ls -l)
+  */
+  EXPECT_EQ(node->type, AST_SUBSHELL);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "out.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_OUTPUT);
+
+  EXPECT_EQ(node->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args->next), "-l");
+  EXPECT_EQ(node->left->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->left->redirects, nullptr);
+
+  EXPECT_EQ(node->right, nullptr);
+
+  destroy_ast(node);
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, OneSubsellWithMultipleRedirects) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l) > out1.txt >> out2.txt
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out1.txt")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_DGREAT, strdup(">>")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out2.txt")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  /*
+  ** SUBSHELL(> out1.txt >> out2.txt)
+  **     |
+  **  COMMAND(ls -l)
+  */
+  t_ast *node = parse_command(&token_list);
+
+  EXPECT_EQ(node->type, AST_SUBSHELL);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects), "out1.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->redirects->next), "out2.txt");
+  EXPECT_EQ(get_redirect_type(node->redirects->next), REDIRECT_APPEND);
+  EXPECT_EQ(node->redirects->next->next, nullptr);
+
+  EXPECT_EQ(node->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->cmd_args->next), "-l");
+  EXPECT_EQ(node->left->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->left->redirects, nullptr);
+
+  EXPECT_EQ(node->right, nullptr);
+
+  destroy_ast(node);
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, MultipleSubshells) {
+  t_token_list *token_list = nullptr;
+
+  // ((ls -l))
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list,
+
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  /*
+  **  SUBSHELL
+  **     |
+  **  SUBSHELL
+  **     |
+  **  COMMAND(ls -l)
+  */
+  t_ast *node = parse_command(&token_list);
+
+  EXPECT_EQ(node->type, AST_SUBSHELL);
+  EXPECT_EQ(node->redirects, nullptr);
+
+  EXPECT_EQ(node->left->type, AST_SUBSHELL);
+  EXPECT_EQ(node->left->redirects, nullptr);
+
+  EXPECT_EQ(node->right, nullptr);
+
+  EXPECT_EQ(node->left->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args->next), "-l");
+  EXPECT_EQ(node->left->left->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->left->left->redirects, nullptr);
+
+  EXPECT_EQ(node->left->right, nullptr);
+
+  destroy_ast(node);
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, UnclosedParenthesis) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_AND_IF, strdup("&&")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  ::testing::internal::CaptureStderr();
+
+  t_ast *node = parse_command(&token_list);
+
+  std::string err_msg = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(node, nullptr);
+  EXPECT_STRCASEEQ(err_msg.c_str(),
+                   "minishell: unexpected token near `newline'\n");
+
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, InvalidTokenPipe) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l | )
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_PIPE, strdup("|")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  ::testing::internal::CaptureStderr();
+
+  t_ast *node = parse_command(&token_list);
+
+  std::string err_msg = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(node, nullptr);
+  EXPECT_STRCASEEQ(err_msg.c_str(), "minishell: unexpected token near `)'\n");
+
+  destroy_token_list(token_list);
+}
+
+TEST(parse_command, InvalidTokenRedirect) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l ) >
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  ::testing::internal::CaptureStderr();
+
+  t_ast *node = parse_command(&token_list);
+
+  std::string err_msg = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(node, nullptr);
+  EXPECT_STRCASEEQ(err_msg.c_str(),
+                   "minishell: unexpected token near `newline'\n");
+
+  destroy_token_list(token_list);
+}

--- a/tests/unit/test_parse_list.cpp
+++ b/tests/unit/test_parse_list.cpp
@@ -354,7 +354,7 @@ TEST(parse_list, ListsInSubshell) {
   t_ast *node6 = node0->right->left;
   t_ast *node7 = node0->right->left->left;
   t_ast *node8 = node0->right->left->left->left;
-  t_ast *node9 = node0->right->left->left->right;
+  t_ast *node9 = node0->right->left->right;
 
   EXPECT_EQ(node0->type, AST_AND);
 

--- a/tests/unit/test_parse_pipeline.cpp
+++ b/tests/unit/test_parse_pipeline.cpp
@@ -96,12 +96,87 @@ TEST(parse_pipeline, MultiplePipelines) {
   destroy_token_list(token_list);
 }
 
+TEST(parse_pipeline, MultiplePipelinesWithSubshells) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l) | (cat -e) > out.txt
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_PIPE, strdup("|")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("cat")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-e")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_GREAT, strdup(">")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("out.txt")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  /*
+  **                PIPE
+  **               |    \
+  **   SUBSHELL(ls -l)  SUBSHELL(cat -e > out.txt)
+  **     |                   |
+  **  COMMAND(ls -l)     COMMAND(cat -e)
+  */
+  t_ast *node = parse_pipeline(&token_list);
+
+  EXPECT_EQ(node->type, AST_PIPE);
+
+  EXPECT_EQ(node->left->type, AST_SUBSHELL);
+
+  EXPECT_EQ(node->right->type, AST_SUBSHELL);
+  EXPECT_EQ(get_redirect_type(node->right->redirects), REDIRECT_OUTPUT);
+  EXPECT_STREQ(get_redirect_filepath(node->right->redirects), "out.txt");
+  EXPECT_EQ(node->right->redirects->next, nullptr);
+
+  EXPECT_EQ(node->left->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args), "ls");
+  EXPECT_STREQ(get_cmd_arg(node->left->left->cmd_args->next), "-l");
+  EXPECT_EQ(node->left->left->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->left->left->redirects, nullptr);
+
+  EXPECT_EQ(node->right->left->type, AST_COMMAND);
+  EXPECT_STREQ(get_cmd_arg(node->right->left->cmd_args), "cat");
+  EXPECT_STREQ(get_cmd_arg(node->right->left->cmd_args->next), "-e");
+  EXPECT_EQ(node->right->left->cmd_args->next->next, nullptr);
+  EXPECT_EQ(node->right->left->redirects, nullptr);
+
+  destroy_ast(node);
+  destroy_token_list(token_list);
+}
+
 TEST(parse_pipeline, InvalidToken) {
   t_token_list *token_list = nullptr;
 
   // ls -l |
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_PIPE, strdup("|")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
+
+  t_ast *node = parse_pipeline(&token_list);
+
+  EXPECT_EQ(node, nullptr);
+
+  destroy_token_list(token_list);
+}
+
+TEST(parse_pipline, InvalidTokenPipe) {
+  t_token_list *token_list = nullptr;
+
+  // (ls -l ) |
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_L_PARENTHESIS, strdup("(")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("ls")));
+  ft_lstadd_back(&token_list, construct_token(TOKEN_WORD, strdup("-l")));
+  ft_lstadd_back(&token_list,
+                 construct_token(TOKEN_R_PARENTHESIS, strdup(")")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_PIPE, strdup("|")));
   ft_lstadd_back(&token_list, construct_token(TOKEN_EOF, nullptr));
 


### PR DESCRIPTION
fix #64
fix #66 

- **Update grammer.md**
- **Refactor parse_simple_command**
- **Implement parse_command.c**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command parsing capabilities, including support for nested commands and redirection.
	- Introduced new parsing functions for commands and redirection handling.

- **Bug Fixes**
	- Improved error handling in command parsing to allow for more robust processing of unexpected node types.
	- Updated error messages for better clarity regarding syntax errors.

- **Tests**
	- Added a comprehensive suite of unit tests for the new command parsing functionality, covering various scenarios and edge cases.
	- Expanded test coverage for parsing lists and pipelines, including validation of subshells and handling of invalid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->