### PR TITLE
100-infinite-error-message-minishell-process_quote-unterminated-quote

### DIFF
--- a/include/token.h
+++ b/include/token.h
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/19 13:27:54 by yliu              #+#    #+#             */
-/*   Updated: 2024/08/30 15:32:32 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/09 10:33:59 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ typedef enum e_token_type
 	TOKEN_GREAT,
 	TOKEN_DGREAT,
 	TOKEN_EOF,
+	TOKEN_UNTERMINATED_QUOTE,
 	TOKEN_UNKNOWN
 }					t_token_type;
 

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/06 12:54:34 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/07 18:05:25 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/09 11:57:45 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,23 @@
 #include "lexer.h"
 #include "parser.h"
 #include "utils.h"
+
+static bool	is_valid_last_token(t_token_list *last_token)
+{
+	if (last_token == NULL)
+		return (false);
+	if (get_token_type(last_token) == TOKEN_UNTERMINATED_QUOTE)
+	{
+		print_error("unterminated quote", get_token_value(last_token));
+		return (false);
+	}
+	if (get_token_type(last_token) == TOKEN_UNKNOWN)
+	{
+		print_error("unknown token", get_token_value(last_token));
+		return (false);
+	}
+	return (true);
+}
 
 int	execute_ast_node(t_ast *node, t_ctx *ctx, t_pipeline_conf *conf)
 {
@@ -43,10 +60,8 @@ void	exec(char *input, t_ctx *ctx)
 	t_pipeline_conf	conf;
 
 	token_list = lexer(input);
-	if (get_token_type(ft_lstlast(token_list)) == TOKEN_UNKNOWN)
+	if (is_valid_last_token(ft_lstlast(token_list)) == false)
 	{
-		print_error("lexer unexpected input",
-			get_token_value(ft_lstlast(token_list)));
 		destroy_token_list(token_list);
 		return ;
 	}

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/19 14:59:01 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/07 18:03:34 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/09 11:39:21 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@ t_token_list	*lexer(const char *input)
 		one_token = get_next_token(&lexer);
 		ft_lstadd_back(&token_list, one_token);
 		if (get_token_type(one_token) == TOKEN_EOF
+			|| get_token_type(one_token) == TOKEN_UNTERMINATED_QUOTE
 			|| get_token_type(one_token) == TOKEN_UNKNOWN)
 			break ;
 	}

--- a/src/lexer/process_quote.c
+++ b/src/lexer/process_quote.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/30 22:45:32 by yliu              #+#    #+#             */
-/*   Updated: 2024/09/04 10:34:07 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/08 20:35:02 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,14 +14,20 @@
 
 t_token_list	*process_quote(t_lexer *lexer)
 {
-	char	left_quote_char;
+	const char	*left_quote_ptr;
+	char		*tmp;
 
-	left_quote_char = *lexer->right;
+	left_quote_ptr = lexer->right;
 	lexer->right++;
-	while (*lexer->right != left_quote_char)
+	while (*lexer->right != *left_quote_ptr)
 	{
 		if (*lexer->right == '\0')
-			print_error("process_quote", "unterminated quote");
+		{
+			lexer->type = TOKEN_UNKNOWN;
+			tmp = ft_xstrndup(left_quote_ptr, lexer->right - left_quote_ptr);
+			lexer->value = tmp;
+			return (construct_token(lexer->type, lexer->value));
+		}
 		lexer->right++;
 	}
 	lexer->right++;

--- a/src/lexer/process_quote.c
+++ b/src/lexer/process_quote.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/30 22:45:32 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/08 20:35:02 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/09 10:33:30 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ t_token_list	*process_quote(t_lexer *lexer)
 	{
 		if (*lexer->right == '\0')
 		{
-			lexer->type = TOKEN_UNKNOWN;
+			lexer->type = TOKEN_UNTERMINATED_QUOTE;
 			tmp = ft_xstrndup(left_quote_ptr, lexer->right - left_quote_ptr);
 			lexer->value = tmp;
 			return (construct_token(lexer->type, lexer->value));

--- a/tests/unit/test_lexer.cpp
+++ b/tests/unit/test_lexer.cpp
@@ -307,3 +307,29 @@ TEST(lexer, AmpersandBeforeSpace) {
   EXPECT_EQ(get_token_type(token->next), TOKEN_WORD);
   EXPECT_STREQ(get_token_value(token->next), "ls");
 }
+
+TEST(lexer, UncloseSingleQuote) {
+  const char *str = "echo 'hello world";
+
+  t_token_list *token = lexer(str);
+
+  EXPECT_EQ(get_token_type(token), TOKEN_WORD);
+  EXPECT_STREQ(get_token_value(token), "echo");
+
+  token = token->next;
+  EXPECT_EQ(get_token_type(token), TOKEN_UNKNOWN);
+  EXPECT_STREQ(get_token_value(token), "'hello world");
+}
+
+TEST(lexer, UncloseDoubleQuote) {
+  const char *str = "echo \"hello world";
+
+  t_token_list *token = lexer(str);
+
+  EXPECT_EQ(get_token_type(token), TOKEN_WORD);
+  EXPECT_STREQ(get_token_value(token), "echo");
+
+  token = token->next;
+  EXPECT_EQ(get_token_type(token), TOKEN_UNKNOWN);
+  EXPECT_STREQ(get_token_value(token), "\"hello world");
+}

--- a/tests/unit/test_lexer.cpp
+++ b/tests/unit/test_lexer.cpp
@@ -317,7 +317,7 @@ TEST(lexer, UncloseSingleQuote) {
   EXPECT_STREQ(get_token_value(token), "echo");
 
   token = token->next;
-  EXPECT_EQ(get_token_type(token), TOKEN_UNKNOWN);
+  EXPECT_EQ(get_token_type(token), TOKEN_UNTERMINATED_QUOTE);
   EXPECT_STREQ(get_token_value(token), "'hello world");
 }
 
@@ -330,6 +330,6 @@ TEST(lexer, UncloseDoubleQuote) {
   EXPECT_STREQ(get_token_value(token), "echo");
 
   token = token->next;
-  EXPECT_EQ(get_token_type(token), TOKEN_UNKNOWN);
+  EXPECT_EQ(get_token_type(token), TOKEN_UNTERMINATED_QUOTE);
   EXPECT_STREQ(get_token_value(token), "\"hello world");
 }


### PR DESCRIPTION
fix #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for unterminated quotes in the lexer, improving robustness and preventing undefined behavior.
	- Added a new token type `TOKEN_UNTERMINATED_QUOTE` to better manage unterminated quotes.

- **Tests**
	- Introduced new unit tests for handling unterminated double and single quotes, ensuring proper error reporting and exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->