### PR TITLE
125-erroneous-expand_variable-when-open-heredoc-file 

### DIFF
--- a/include/expansion.h
+++ b/include/expansion.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expansion.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/23 14:58:13 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/01 13:33:44 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/07 15:41:25 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 
 t_list	*expand(t_list *cmd_args, t_ctx *ctx);
 
-char	*expand_variable(char *str, t_ctx *ctx);
+char	*expand_variable(char *str, t_ctx *ctx, bool is_smart_expand);
 char	*expand_quotes(char *str);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/01 22:27:21 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/06 14:08:40 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 16:00:56 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,5 +66,5 @@ t_string		*construct_string_struct(char *input);
 void			consume_char(t_string *string);
 void			destroy_string_struct(t_string *string);
 char			*trim(t_string *string);
-char			*trim_till(t_string *string, char *set);
+char			*trim_till(t_string *string, const char *set);
 #endif

--- a/src/exec/open_heredoc.c
+++ b/src/exec/open_heredoc.c
@@ -35,7 +35,7 @@ static int	open_pipe_expanded_heredoc(t_redirect_info *info, t_ctx *ctx)
 		line = get_next_line(info->heredoc_fd);
 		if (line == NULL)
 			break ;
-		expanded = expand_variable(line, ctx);
+		expanded = expand_variable(line, ctx, false);
 		ft_putstr_fd(expanded, pipe_fd[1]);
 		free(line);
 		free(expanded);
@@ -60,7 +60,7 @@ static int	open_tmpfile_expanded_heredoc(t_redirect_info *info, t_ctx *ctx)
 		line = get_next_line(info->heredoc_fd);
 		if (line == NULL)
 			break ;
-		expanded = expand_variable(line, ctx);
+		expanded = expand_variable(line, ctx, false);
 		ft_putendl_fd(expanded, fd);
 		free(line);
 		free(expanded);

--- a/src/expansion/expand_variable.c
+++ b/src/expansion/expand_variable.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:08:50 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/07 16:17:32 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 21:24:08 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ static char	*trim_single_quotes(t_expand_info *expand_info)
 	return (trim(expand_info));
 }
 
-static const char	*construct_lookup(bool is_smart_expand)
+static const char	*choose_lookup(bool is_smart_expand)
 {
 	if (is_smart_expand)
 		return ("$\'");
@@ -37,7 +37,7 @@ char	*expand_variable(char *input, t_ctx *ctx, bool is_smart_expand)
 	char			*expanded;
 	const char		*lookup;
 
-	lookup = construct_lookup(is_smart_expand);
+	lookup = choose_lookup(is_smart_expand);
 	expand_info = construct_string_struct(input);
 	expanded = NULL;
 	while (*expand_info->right)

--- a/src/expansion/expand_variable.c
+++ b/src/expansion/expand_variable.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:08:50 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/07 16:01:09 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 16:16:43 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ static const char	*construct_lookup(bool is_smart_expand)
 char	*expand_variable(char *input, t_ctx *ctx, bool is_smart_expand)
 {
 	t_expand_info	*expand_info;
-	char			*trimed;
+	char			*trimmed;
 	char			*expanded;
 	const char		*lookup;
 
@@ -43,13 +43,13 @@ char	*expand_variable(char *input, t_ctx *ctx, bool is_smart_expand)
 	while (*expand_info->right)
 	{
 		if (*expand_info->right == '\'' && is_smart_expand)
-			trimed = trim_single_quotes(expand_info);
+			trimmed = trim_single_quotes(expand_info);
 		else if (*expand_info->right == '$')
-			trimed = trim_expanded_variable(expand_info, ctx);
+			trimmed = trim_expanded_variable(expand_info, ctx);
 		else
-			trimed = trim_till(expand_info, lookup);
-		expanded = ft_xstrjoin2(expanded, trimed);
-		free(trimed);
+			trimmed = trim_till(expand_info, lookup);
+		expanded = ft_xstrjoin2(expanded, trimmed);
+		free(trimmed);
 	}
 	destroy_string_struct(expand_info);
 	free((char *)lookup);

--- a/src/expansion/expand_variable.c
+++ b/src/expansion/expand_variable.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:08:50 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/07 16:16:43 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 16:17:32 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,9 +25,9 @@ static char	*trim_single_quotes(t_expand_info *expand_info)
 static const char	*construct_lookup(bool is_smart_expand)
 {
 	if (is_smart_expand)
-		return (ft_xstrdup("$\'"));
+		return ("$\'");
 	else
-		return (ft_xstrdup("$"));
+		return ("$");
 }
 
 char	*expand_variable(char *input, t_ctx *ctx, bool is_smart_expand)
@@ -52,6 +52,5 @@ char	*expand_variable(char *input, t_ctx *ctx, bool is_smart_expand)
 		free(trimmed);
 	}
 	destroy_string_struct(expand_info);
-	free((char *)lookup);
 	return (expanded);
 }

--- a/src/expansion/expand_variable.c
+++ b/src/expansion/expand_variable.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:08:50 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/05 19:01:57 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 16:01:09 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,25 +22,36 @@ static char	*trim_single_quotes(t_expand_info *expand_info)
 	return (trim(expand_info));
 }
 
-char	*expand_variable(char *input, t_ctx *ctx)
+static const char	*construct_lookup(bool is_smart_expand)
+{
+	if (is_smart_expand)
+		return (ft_xstrdup("$\'"));
+	else
+		return (ft_xstrdup("$"));
+}
+
+char	*expand_variable(char *input, t_ctx *ctx, bool is_smart_expand)
 {
 	t_expand_info	*expand_info;
 	char			*trimed;
 	char			*expanded;
+	const char		*lookup;
 
+	lookup = construct_lookup(is_smart_expand);
 	expand_info = construct_string_struct(input);
 	expanded = NULL;
 	while (*expand_info->right)
 	{
-		if (*expand_info->right == '\'')
+		if (*expand_info->right == '\'' && is_smart_expand)
 			trimed = trim_single_quotes(expand_info);
 		else if (*expand_info->right == '$')
 			trimed = trim_expanded_variable(expand_info, ctx);
 		else
-			trimed = trim_till(expand_info, "$\'");
+			trimed = trim_till(expand_info, lookup);
 		expanded = ft_xstrjoin2(expanded, trimed);
 		free(trimed);
 	}
 	destroy_string_struct(expand_info);
+	free((char *)lookup);
 	return (expanded);
 }

--- a/src/expansion/expand_variable_on_list.c
+++ b/src/expansion/expand_variable_on_list.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/02 12:37:49 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/05 14:51:57 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 15:41:12 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ t_list	*expand_variable_on_list(t_list *list, t_ctx *ctx)
 	result = NULL;
 	while (curr)
 	{
-		ifs_combined_word = expand_variable(curr->content, ctx);
+		ifs_combined_word = expand_variable(curr->content, ctx, true);
 		original_ptr = ifs_combined_word;
 		while (true)
 		{

--- a/src/expansion/expansion_internal.h
+++ b/src/expansion/expansion_internal.h
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/24 12:09:46 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/06 14:08:30 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 16:01:45 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,9 +18,11 @@
 
 typedef t_string	t_expand_info;
 
+char				*expand_variable(char *str, t_ctx *ctx,
+						bool is_smart_expand);
 char				*expand_quotes(char *input);
+
 t_list				*expand_quotes_on_list(t_list *list);
-char				*expand_variable(char *str, t_ctx *ctx);
 t_list				*expand_variable_on_list(t_list *list, t_ctx *ctx);
 t_list				*expand_wildcard_on_list(t_list *list);
 

--- a/src/utils/string_struct.c
+++ b/src/utils/string_struct.c
@@ -6,7 +6,7 @@
 /*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/05 17:52:16 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/05 19:04:06 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/07 15:43:42 by yliu             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ char	*trim(t_string *string)
 	return (result);
 }
 
-char	*trim_till(t_string *string, char *set)
+char	*trim_till(t_string *string, const char *set)
 {
 	while (*string->right && !ft_strchr(set, *string->right))
 		string->right++;


### PR DESCRIPTION
fix #125 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced variable expansion functionality with the addition of a `smart_expand` parameter, allowing for more nuanced handling of variable expansion.
	- New test cases added to validate the behavior of variable expansion with the `smart_expand` parameter set to both `true` and `false`.

- **Bug Fixes**
	- Improved type safety in the `trim_till` function by changing parameter types.

- **Documentation**
	- Updated function signatures in relevant header files to reflect the new parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->