### PR TITLE
131 input such as `''`, `""` displays unappropriate err msg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ WHITE			= \033[0;97m
 
 # Rules
 .PHONY: all
-all: CFLAGS += $(DEV_FLAGS)
+all: CFLAGS += $(PROD_FLAGS)
 all: $(NAME)
 
 $(NAME): $(LIBFT) $(LIBREADLINE) $(SRC) $(OBJ) $(HEADER)

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ WHITE			= \033[0;97m
 
 # Rules
 .PHONY: all
-all: CFLAGS += $(PROD_FLAGS)
+all: CFLAGS += $(DEV_FLAGS)
 all: $(NAME)
 
 $(NAME): $(LIBFT) $(LIBREADLINE) $(SRC) $(OBJ) $(HEADER)

--- a/src/exec/spawn_command.c
+++ b/src/exec/spawn_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/26 23:25:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/01 13:35:25 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/09 19:50:56 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ static char	*search_for_command(char *basename, t_env_list *env_list)
 		tmp = ft_xstrjoin(paths[i], "/");
 		joined_path = ft_xstrjoin(tmp, basename);
 		free(tmp);
-		if (access(joined_path, X_OK) == 0)
+		if (access(joined_path, X_OK) == 0 && !is_a_directory(joined_path))
 		{
 			ft_free_strs(paths);
 			return (joined_path);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 13:59:54 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/09 20:11:02 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/09 20:14:11 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,15 +41,15 @@ static void	loop(t_ctx *ctx)
 	while (true)
 	{
 		input = readline(PROMPT);
+		if (input == NULL)
+		{
+			printf("exit\n");
+			break ;
+		}
 		if (ft_strcmp(input, "") == 0)
 		{
 			free(input);
 			continue ;
-		}
-		if (input == NULL)
-		{
-			ft_printf("exit\n");
-			break ;
 		}
 		exec(input, ctx);
 		add_history(input);

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
+/*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 13:59:54 by reasuke           #+#    #+#             */
-/*   Updated: 2024/09/29 16:13:13 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/09 20:11:02 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,20 +34,18 @@ static void	destroy_ctx(t_ctx *ctx)
 	free(ctx);
 }
 
-int	main(int argc, char **argv, char **envp)
+static void	loop(t_ctx *ctx)
 {
-	char			*input;
-	t_ctx			*ctx;
-	struct termios	original_termios;
+	char	*input;
 
-	(void)argc;
-	(void)argv;
-	ctx = construct_ctx(envp);
-	init_signal_handlers();
-	save_terminal_configuration(&original_termios);
 	while (true)
 	{
 		input = readline(PROMPT);
+		if (ft_strcmp(input, "") == 0)
+		{
+			free(input);
+			continue ;
+		}
 		if (input == NULL)
 		{
 			ft_printf("exit\n");
@@ -56,8 +54,20 @@ int	main(int argc, char **argv, char **envp)
 		exec(input, ctx);
 		add_history(input);
 		free(input);
-		restore_terminal_configuration(&original_termios);
 	}
+}
+
+int	main(int argc, char **argv, char **envp)
+{
+	t_ctx			*ctx;
+	struct termios	original_termios;
+
+	(void)argc;
+	(void)argv;
+	ctx = construct_ctx(envp);
+	init_signal_handlers();
+	save_terminal_configuration(&original_termios);
+	loop(ctx);
 	destroy_env_list(ctx->env);
 	destroy_ctx(ctx);
 	return (EXIT_SUCCESS);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/25 13:59:54 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/09 20:14:11 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/10 18:50:12 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ static void	destroy_ctx(t_ctx *ctx)
 	free(ctx);
 }
 
-static void	loop(t_ctx *ctx)
+static void	loop(t_ctx *ctx, struct termios *original_termios)
 {
 	char	*input;
 
@@ -54,6 +54,7 @@ static void	loop(t_ctx *ctx)
 		exec(input, ctx);
 		add_history(input);
 		free(input);
+		restore_terminal_configuration(original_termios);
 	}
 }
 
@@ -67,7 +68,7 @@ int	main(int argc, char **argv, char **envp)
 	ctx = construct_ctx(envp);
 	init_signal_handlers();
 	save_terminal_configuration(&original_termios);
-	loop(ctx);
+	loop(ctx, &original_termios);
 	destroy_env_list(ctx->env);
 	destroy_ctx(ctx);
 	return (EXIT_SUCCESS);

--- a/tests/e2e/test_execute_simple_command.py
+++ b/tests/e2e/test_execute_simple_command.py
@@ -48,6 +48,22 @@ def test_relative_shell_script(shell_session):
             os.remove(test_file)
 
 
+def test_error_empty_command(shell_session):
+    shell_session.sendline("''")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "minishell: : command not found"
+
+
+def test_error_dotdot(shell_session):
+    shell_session.sendline("..")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "minishell: ..: command not found"
+
+
 def test_error_command_not_found(shell_session):
     shell_session.sendline("aaaaaaaaaaaaaaaaaaa")
     shell_session.expect(PROMPT)


### PR DESCRIPTION
fix #131

- **Fix condition of search_for_command**
- **Add e2e tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command search functionality to ensure only valid and executable command paths are returned.
	- Restructured main execution flow for improved clarity and input handling.

- **Bug Fixes**
	- Improved error handling in shell command execution.

- **Tests**
	- Added tests to verify correct error handling for empty commands and the `..` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->