### PR TITLE
153 input string only consists of space or tab displays syntax error

### DIFF
--- a/src/routine/loop.c
+++ b/src/routine/loop.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/19 16:12:25 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/19 16:23:31 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/19 18:51:44 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,21 @@ static void	exec(char *input, t_ctx *ctx)
 	destroy_ast(node);
 }
 
+static bool	is_empty_input(char *input)
+{
+	char	*trimmed_input;
+
+	trimmed_input = ft_strtrim(input, " \t\n");
+	if (ft_strcmp(trimmed_input, "") == 0)
+	{
+		free(trimmed_input);
+		free(input);
+		return (true);
+	}
+	free(trimmed_input);
+	return (false);
+}
+
 void	loop(t_ctx *ctx)
 {
 	char			*input;
@@ -78,11 +93,8 @@ void	loop(t_ctx *ctx)
 			printf("exit\n");
 			break ;
 		}
-		if (ft_strcmp(input, "") == 0)
-		{
-			free(input);
+		if (is_empty_input(input))
 			continue ;
-		}
 		exec(input, ctx);
 		add_history(input);
 		free(input);

--- a/tests/e2e/test_execute_simple_command.py
+++ b/tests/e2e/test_execute_simple_command.py
@@ -48,6 +48,22 @@ def test_relative_shell_script(shell_session):
             os.remove(test_file)
 
 
+def test_empty_command(shell_session):
+    shell_session.sendline("")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == ""
+
+
+def test_empty_command_with_spaces(shell_session):
+    shell_session.sendline(" \t  \n ")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == ""
+
+
 def test_error_empty_command(shell_session):
     shell_session.sendline("''")
     shell_session.expect(PROMPT)


### PR DESCRIPTION
fix #153

- **Handle empty input**
- **Add e2e tests**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function to check for empty input, enhancing command handling in the shell.
- **Bug Fixes**
	- Added tests for handling empty commands and commands with only whitespace to ensure correct shell behavior.
	- Corrected indentation in an existing test function for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->