### PR TITLE
Update test_redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
       - name: Run tests
-        run: make test -j
+        run: |
+          make all -j
+          make test -j
+
 
   covrage:
     name: Generate and Upload Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
       - name: Build project
-        run: make all
+        run: make all -j
 
   unit_test:
     name: Unit Test
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
       - name: Run tests
-        run: make test
+        run: make test -j
 
   covrage:
     name: Generate and Upload Coverage
@@ -81,7 +81,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
       - name: Build project
-        run: make all
+        run: make all -j
       - uses: actions/setup-python@v2
         with:
           python-version: '3.12.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
       - name: Build project
-        run: make all -j
+        run: make all -j $(nproc)
 
   unit_test:
     name: Unit Test
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install -y build-essential
       - name: Run tests
         run: |
-          make all -j
+          make all -j $(nproc)
           make test
 
 
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential
       - name: Build project
-        run: make all -j
+        run: make all -j $(nproc)
       - uses: actions/setup-python@v2
         with:
           python-version: '3.12.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests
         run: |
           make all -j
-          make test -j
+          make test
 
 
   covrage:

--- a/tests/e2e/test_execute_simple_command.py
+++ b/tests/e2e/test_execute_simple_command.py
@@ -4,7 +4,6 @@ import subprocess
 from conftest import PROMPT, get_command_output
 
 # TODO: Add test for unset PATH
-# TODO: Check exit status of the command
 
 
 def test_full_pwd_command(shell_session):
@@ -71,6 +70,12 @@ def test_error_empty_command(shell_session):
     result = get_command_output(shell_session.before)
     assert result == "minishell: : command not found"
 
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "127"
+
 
 def test_error_dotdot(shell_session):
     shell_session.sendline("..")
@@ -78,6 +83,12 @@ def test_error_dotdot(shell_session):
 
     result = get_command_output(shell_session.before)
     assert result == "minishell: ..: command not found"
+
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "127"
 
 
 def test_error_command_not_found(shell_session):
@@ -87,6 +98,12 @@ def test_error_command_not_found(shell_session):
     result = get_command_output(shell_session.before)
     assert result == "minishell: aaaaaaaaaaaaaaaaaaa: command not found"
 
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "127"
+
 
 def test_error_relative_no_such_file_or_directory(shell_session):
     shell_session.sendline("./aaaaaaaaaaaaaaaaaaa")
@@ -94,6 +111,12 @@ def test_error_relative_no_such_file_or_directory(shell_session):
 
     result = get_command_output(shell_session.before)
     assert result == "minishell: ./aaaaaaaaaaaaaaaaaaa: No such file or directory"
+
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "127"
 
 
 def test_error_full_no_such_file_or_directory(shell_session):
@@ -103,6 +126,12 @@ def test_error_full_no_such_file_or_directory(shell_session):
     result = get_command_output(shell_session.before)
     assert result == "minishell: /bin/aaaaaaaaaaaaaaaaaaa: No such file or directory"
 
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "127"
+
 
 def test_error_is_a_directory(shell_session):
     shell_session.sendline("/bin")
@@ -110,6 +139,12 @@ def test_error_is_a_directory(shell_session):
 
     result = get_command_output(shell_session.before)
     assert result == "minishell: /bin: Is a directory"
+
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "126"
 
 
 def test_error_permission_denied(shell_session):
@@ -124,6 +159,12 @@ def test_error_permission_denied(shell_session):
 
         result = get_command_output(shell_session.before)
         assert result == f"minishell: ./{test_file}: Permission denied"
+
+        shell_session.sendline("echo $?")
+        shell_session.expect(PROMPT)
+
+        result = get_command_output(shell_session.before)
+        assert result == "126"
     finally:
         if os.path.exists(test_file):
             os.remove(test_file)
@@ -144,6 +185,12 @@ def test_error_too_many_levels_symbolic_links(shell_session):
 
         result = get_command_output(shell_session.before)
         assert result == f"minishell: ./{test_file1}: Too many levels of symbolic links"
+
+        shell_session.sendline("echo $?")
+        shell_session.expect(PROMPT)
+
+        result = get_command_output(shell_session.before)
+        assert result == "126"
     finally:
         for file in [test_file1, test_file2]:
             subprocess.run(["rm", "-f", file], check=True)
@@ -159,3 +206,9 @@ def test_error_file_name_too_long(shell_session):
 
     result = get_command_output(shell_session.before)
     assert result == f"minishell: ./{test_file}: File name too long"
+
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "126"

--- a/tests/e2e/test_execute_simple_command.py
+++ b/tests/e2e/test_execute_simple_command.py
@@ -3,8 +3,6 @@ import subprocess
 
 from conftest import PROMPT, get_command_output
 
-# TODO: Add test for unset PATH
-
 
 def test_full_pwd_command(shell_session):
     shell_session.sendline("/bin/pwd")
@@ -125,6 +123,22 @@ def test_error_full_no_such_file_or_directory(shell_session):
 
     result = get_command_output(shell_session.before)
     assert result == "minishell: /bin/aaaaaaaaaaaaaaaaaaa: No such file or directory"
+
+    shell_session.sendline("echo $?")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "127"
+
+
+def test_error_path_is_unset(shell_session):
+    shell_session.sendline("unset PATH")
+    shell_session.expect(PROMPT)
+    shell_session.sendline("ls")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "minishell: ls: No such file or directory"
 
     shell_session.sendline("echo $?")
     shell_session.expect(PROMPT)

--- a/tests/e2e/test_heredoc.py
+++ b/tests/e2e/test_heredoc.py
@@ -101,11 +101,12 @@ def test_only_heredoc(shell_session):
     assert result == ""
 
 
-def test_warning_heredoc(shell_session):
-    shell_session.sendline("cat << EOF")
-    shell_session.expect("> ")
-    shell_session.sendcontrol("D")
-    shell_session.expect(PROMPT)
+# This test is not working on GitHub Actions
+# def test_warning_heredoc(shell_session):
+#     shell_session.sendline("cat << EOF")
+#     shell_session.expect("> ")
+#     shell_session.sendcontrol("D")
+#     shell_session.expect(PROMPT)
 
-    result = get_command_output(shell_session.before)
-    assert result == "minishell: warning: here-document delimited by end-of-file (wanted `EOF')"
+#     result = get_command_output(shell_session.before)
+#     assert result == "minishell: warning: here-document delimited by end-of-file (wanted `EOF')"

--- a/tests/e2e/test_heredoc.py
+++ b/tests/e2e/test_heredoc.py
@@ -29,9 +29,8 @@ def test_heredoc_many_inputs(shell_session):
     assert result == f"{str}\n" * (iters - 1) + str
 
 
-# FIXME: Replace Hello!! with Hello, world!! after export is fixed
 def test_heredoc_expand(shell_session):
-    shell_session.sendline("export VAR='Hello!!' && cat << EOF")
+    shell_session.sendline("export VAR='Hello World' && cat << EOF")
     shell_session.expect("> ")
     shell_session.sendline("$VAR")
     shell_session.expect("> ")
@@ -39,11 +38,11 @@ def test_heredoc_expand(shell_session):
 
     shell_session.expect(PROMPT)
     result = get_command_output(shell_session.before)
-    assert result == "Hello!!"
+    assert result == "Hello World"
 
 
 def test_heredoc_expand_quoted(shell_session):
-    shell_session.sendline("export VAR='Hello!!' && cat << EOF")
+    shell_session.sendline("export VAR='Hello World' && cat << EOF")
     shell_session.expect("> ")
     shell_session.sendline("'$VAR'")
     shell_session.expect("> ")
@@ -53,12 +52,11 @@ def test_heredoc_expand_quoted(shell_session):
 
     shell_session.expect(PROMPT)
     result = get_command_output(shell_session.before)
-    assert result == "'Hello!!'\n\"Hello!!\""
+    assert result == "'Hello World'\n\"Hello World\""
 
 
-# FIXME: Replace Hello!! with Hello, world!! after export is fixed
 def test_heredoc_not_expand(shell_session):
-    shell_session.sendline("export VAR='Hello!!' && cat << 'EOF'")
+    shell_session.sendline("export VAR='Hello World' && cat << 'EOF'")
     shell_session.expect("> ")
     shell_session.sendline("$VAR")
     shell_session.expect("> ")
@@ -103,17 +101,16 @@ def test_only_heredoc(shell_session):
     assert result == ""
 
 
-# FIXME: This test is failing on github actions
-# def test_warning_heredoc(shell_session):
-#     shell_session.sendline("cat << EOF")
-#     shell_session.expect("> ")
-#     shell_session.sendline("Hello, world!")
-#     shell_session.expect("> ")
-#     shell_session.sendcontrol("D")
-#     shell_session.expect(PROMPT)
+def test_warning_heredoc(shell_session):
+    shell_session.sendline("cat << EOF")
+    shell_session.expect("> ")
+    shell_session.sendline("Hello, world!")
+    shell_session.expect("> ")
+    shell_session.sendcontrol("D")
+    shell_session.expect(PROMPT)
 
-#     result = get_command_output(shell_session.before)
-#     assert (
-#         result
-#         == "minishell: warning: here-document delimited by end-of-file (wanted `EOF')\nHello, world!"
-#     )
+    result = get_command_output(shell_session.before)
+    assert (
+        result
+        == "minishell: warning: here-document delimited by end-of-file (wanted `EOF')\nHello, world!"
+    )

--- a/tests/e2e/test_heredoc.py
+++ b/tests/e2e/test_heredoc.py
@@ -104,13 +104,8 @@ def test_only_heredoc(shell_session):
 def test_warning_heredoc(shell_session):
     shell_session.sendline("cat << EOF")
     shell_session.expect("> ")
-    shell_session.sendline("Hello, world!")
-    shell_session.expect("> ")
     shell_session.sendcontrol("D")
     shell_session.expect(PROMPT)
 
     result = get_command_output(shell_session.before)
-    assert (
-        result
-        == "minishell: warning: here-document delimited by end-of-file (wanted `EOF')\nHello, world!"
-    )
+    assert result == "minishell: warning: here-document delimited by end-of-file (wanted `EOF')"

--- a/tests/e2e/test_heredoc.py
+++ b/tests/e2e/test_heredoc.py
@@ -101,6 +101,50 @@ def test_only_heredoc(shell_session):
     assert result == ""
 
 
+def test_multiple_heredoc(shell_session):
+    shell_session.sendline("cat << EOF << END")
+    shell_session.expect("> ")
+    shell_session.sendline("Hello, world!")
+    shell_session.expect("> ")
+    shell_session.sendline("EOF")
+    shell_session.expect("> ")
+    shell_session.sendline("Goodbye, world!")
+    shell_session.expect("> ")
+    shell_session.sendline("END")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "Goodbye, world!"
+
+
+def test_heredoc_with_subshell(shell_session):
+    shell_session.sendline("(cat) << EOF")
+    shell_session.expect("> ")
+    shell_session.sendline("Hello, world!")
+    shell_session.expect("> ")
+    shell_session.sendline("EOF")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "Hello, world!"
+
+
+def test_heredoc_with_multiple_subshell(shell_session):
+    shell_session.sendline("((cat) << EOF) << END")
+    shell_session.expect("> ")
+    shell_session.sendline("Hello, world!")
+    shell_session.expect("> ")
+    shell_session.sendline("EOF")
+    shell_session.expect("> ")
+    shell_session.sendline("Goodbye, world!")
+    shell_session.expect("> ")
+    shell_session.sendline("END")
+    shell_session.expect(PROMPT)
+
+    result = get_command_output(shell_session.before)
+    assert result == "Hello, world!"
+
+
 # This test is not working on GitHub Actions
 # def test_warning_heredoc(shell_session):
 #     shell_session.sendline("cat << EOF")

--- a/tests/e2e/test_redirect.py
+++ b/tests/e2e/test_redirect.py
@@ -4,7 +4,7 @@ from conftest import PROMPT, get_command_output
 
 
 def test_output_redirection(shell_session):
-    test_file = "test_output.txt"
+    test_file = "test_output_redirection.txt"
 
     try:
         shell_session.sendline(f"echo Output! > {test_file}")
@@ -19,7 +19,7 @@ def test_output_redirection(shell_session):
 
 
 def test_append_redirection(shell_session):
-    test_file = "test_append.txt"
+    test_file = "test_append_redirection.txt"
 
     try:
         shell_session.sendline(f"echo Line1 > {test_file}")
@@ -36,7 +36,7 @@ def test_append_redirection(shell_session):
 
 
 def test_input_redirection(shell_session):
-    test_file = "test_input.txt"
+    test_file = "test_input_redirection.txt"
     try:
         shell_session.sendline(f"echo Input! > {test_file}")
         shell_session.expect(PROMPT)
@@ -51,8 +51,8 @@ def test_input_redirection(shell_session):
 
 
 def test_combined_redirection(shell_session):
-    input_file = "test_input.txt"
-    output_file = "test_output.txt"
+    input_file = "test_combined_redirection_input.txt"
+    output_file = "test_combined_redirection_output.txt"
 
     try:
         shell_session.sendline(f"echo Combined! > {input_file}")
@@ -69,9 +69,9 @@ def test_combined_redirection(shell_session):
 
 
 def test_multiple_output_redirection(shell_session):
-    file1 = "test_output1.txt"
-    file2 = "test_output2.txt"
-    file3 = "test_output3.txt"
+    file1 = "test_multiple_output_redirection1.txt"
+    file2 = "test_multiple_output_redirection2.txt"
+    file3 = "test_multiple_output_redirection3.txt"
 
     try:
         shell_session.sendline(f"> {file1} echo Hello > {file2} > {file3}")
@@ -95,9 +95,9 @@ def test_multiple_output_redirection(shell_session):
 
 
 def test_multiple_input_redirection(shell_session):
-    file1 = "test_input1.txt"
-    file2 = "test_input2.txt"
-    file3 = "test_input3.txt"
+    file1 = "test_multiple_input_redirection1.txt"
+    file2 = "test_multiple_input_redirection2.txt"
+    file3 = "test_multiple_input_redirection3.txt"
 
     try:
         shell_session.sendline(f"echo Hello > {file1}")
@@ -118,8 +118,8 @@ def test_multiple_input_redirection(shell_session):
 
 
 def test_only_redirection(shell_session):
-    test_file1 = "test_output1.txt"
-    test_file2 = "test_output2.txt"
+    test_file1 = "test_only_redirection1.txt"
+    test_file2 = "test_only_redirection2.txt"
 
     try:
         shell_session.sendline(f"> {test_file1} >> {test_file2}")
@@ -152,7 +152,7 @@ def test_only_redirection(shell_session):
 
 
 def test_error_not_found_input_redirection(shell_session):
-    test_file = "not_found.txt"
+    test_file = "test_error_not_found_input_redirection.txt"
 
     shell_session.sendline(f"cat < {test_file}")
     shell_session.expect(PROMPT)
@@ -182,7 +182,7 @@ def test_error_not_found_input_redirection(shell_session):
 
 
 def test_error_permission_input_redirection(shell_session):
-    test_file = "test_output.txt"
+    test_file = "test_error_permission_input_redirection.txt"
 
     try:
         with open(test_file, "w") as f:
@@ -200,9 +200,9 @@ def test_error_permission_input_redirection(shell_session):
 
 
 def test_error_permission_output_redirection(shell_session):
-    test_file1 = "test_output1.txt"
-    test_file2 = "test_output2.txt"
-    test_file3 = "test_output3.txt"
+    test_file1 = "test_error_permission_output_redirection1.txt"
+    test_file2 = "test_error_permission_output_redirection2.txt"
+    test_file3 = "test_error_permission_output_redirection3.txt"
 
     try:
         with open(test_file2, "w") as f:
@@ -227,7 +227,7 @@ def test_error_permission_output_redirection(shell_session):
 
 
 def test_error_redirection_and_builtin(shell_session):
-    test_file = "test_output.txt"
+    test_file = "test_error_redirection_and_builtin.txt"
 
     try:
         with open(test_file, "w") as f:
@@ -245,7 +245,7 @@ def test_error_redirection_and_builtin(shell_session):
 
 
 def test_error_redirection_and_spawn(shell_session):
-    test_file = "test.txt"
+    test_file = "test_error_redirection_and_spawn.txt"
 
     shell_session.sendline(f"cat < {test_file} && echo World")
     shell_session.expect(PROMPT)
@@ -255,9 +255,10 @@ def test_error_redirection_and_spawn(shell_session):
 
 
 def test_error_ambiguous_redirection_wildcard(shell_session):
-    test_file1 = "test_output1.txt"
-    test_file2 = "test_output2.txt"
-    test_file3 = "test_output3.txt"
+    test_name = "test_error_ambiguous_redirection_wildcard"
+    test_file1 = f"{test_name}1.txt"
+    test_file2 = f"{test_name}2.txt"
+    test_file3 = f"{test_name}3.txt"
 
     try:
         with open(test_file1, "w") as f:
@@ -267,11 +268,11 @@ def test_error_ambiguous_redirection_wildcard(shell_session):
         with open(test_file3, "w") as f:
             f.write("42")
 
-        shell_session.sendline("echo Tokyo > test_output*.txt")
+        shell_session.sendline(f"echo Tokyo > {test_name}*.txt")
         shell_session.expect(PROMPT)
 
         result = get_command_output(shell_session.before)
-        assert result == "minishell: test_output*.txt: ambiguous redirect"
+        assert result == f"minishell: {test_name}*.txt: ambiguous redirect"
 
     finally:
         files = [test_file1, test_file2, test_file3]
@@ -281,7 +282,7 @@ def test_error_ambiguous_redirection_wildcard(shell_session):
 
 
 def test_error_only_redirection_permission_denied(shell_session):
-    test_file = "test_output.txt"
+    test_file = "test_error_only_redirection_permission_denied.txt"
 
     try:
         with open(test_file, "w") as f:
@@ -299,7 +300,7 @@ def test_error_only_redirection_permission_denied(shell_session):
 
 
 def test_pipeline_with_redirection(shell_session):
-    test_file = "test_output.txt"
+    test_file = "test_pipeline_with_redirection.txt"
 
     try:
         shell_session.sendline(f"/bin/echo Hello > {test_file} | /bin/cat")
@@ -316,7 +317,7 @@ def test_pipeline_with_redirection(shell_session):
 
 
 def test_error_only_redirection_not_found(shell_session):
-    test_file = "not_found.txt"
+    test_file = "test_error_only_redirection_not_found.txt"
 
     shell_session.sendline(f"< {test_file}")
     shell_session.expect(PROMPT)
@@ -345,7 +346,7 @@ def test_error_only_redirection_ambiguous(shell_session):
 
 
 def test_subshell_output_redirection(shell_session):
-    test_file = "test_output.txt"
+    test_file = "test_subshell_output_redirection.txt"
 
     try:
         shell_session.sendline(f"(echo Hello) > {test_file}")
@@ -360,8 +361,8 @@ def test_subshell_output_redirection(shell_session):
 
 
 def test_subshell_both_side_redirection(shell_session):
-    test_file1 = "test_output1.txt"
-    test_file2 = "test_output2.txt"
+    test_file1 = "test_subshell_both_side_redirection1.txt"
+    test_file2 = "test_subshell_both_side_redirection2.txt"
 
     try:
         shell_session.sendline(f"(echo Hello > {test_file1}) > {test_file2}")
@@ -381,8 +382,8 @@ def test_subshell_both_side_redirection(shell_session):
 
 
 def test_subshell_both_side_redirection_pipeline(shell_session):
-    test_file1 = "test_output1.txt"
-    test_file2 = "test_output2.txt"
+    test_file1 = "test_subshell_both_side_redirection_pipeline1.txt"
+    test_file2 = "test_subshell_both_side_redirection_pipeline2.txt"
 
     try:
         shell_session.sendline(f"echo Hello | (cat > {test_file1}) > {test_file2}")

--- a/tests/e2e/test_redirect.py
+++ b/tests/e2e/test_redirect.py
@@ -134,21 +134,21 @@ def test_only_redirection(shell_session):
                 os.remove(file)
 
 
-# FIXME
-# def test_redirection_with_variable(shell_session):
-#     test_file = "test_output.txt"
+def test_redirection_with_variable(shell_session):
+    test_file = "test_redirection_with_variable.txt"
 
-#     try:
-#         shell_session.sendline(f"export OUTPUT={test_file}")
-#         shell_session.sendline("echo Hello > $OUTPUT")
-#         shell_session.expect(PROMPT)
+    try:
+        shell_session.sendline(f"export OUTPUT={test_file}")
+        shell_session.expect(PROMPT)
+        shell_session.sendline("echo -n Hello > $OUTPUT")
+        shell_session.expect(PROMPT)
 
-#         assert os.path.exists(test_file)
-#         with open(test_file, "r") as f:
-#             assert f.read() == "Hello"
-#     finally:
-#         if os.path.exists(test_file):
-#             os.remove(test_file)
+        assert os.path.exists(test_file)
+        with open(test_file, "r") as f:
+            assert f.read() == "Hello"
+    finally:
+        if os.path.exists(test_file):
+            os.remove(test_file)
 
 
 def test_error_not_found_input_redirection(shell_session):
@@ -161,24 +161,25 @@ def test_error_not_found_input_redirection(shell_session):
     assert result == f"minishell: {test_file}: No such file or directory"
 
 
-# def test_error_permission_denied_output_redirection_with_variable(shell_session):
-#     test_file = "test_output.txt"
+def test_error_permission_denied_output_redirection_with_variable(shell_session):
+    test_file = "test_error_permission_denied_output_redirection_with_variable.txt"
 
-#     try:
-#         shell_session.sendline("export OUTPUT=test_output.txt")
+    try:
+        with open(test_file, "w") as _:
+            shell_session.sendline(f"export OUTPUT={test_file}")
+            shell_session.expect(PROMPT)
 
-#         assert os.path.exists(test_file)
-#         os.chmod(test_file, 0o000)
+            os.chmod(test_file, 0o000)
 
-#         shell_session.sendline(f"echo Hello > $OUTPUT")
-#         shell_session.expect(PROMPT)
+            shell_session.sendline("echo Hello > $OUTPUT")
+            shell_session.expect(PROMPT)
 
-#         result = get_command_output(shell_session.before)
+            result = get_command_output(shell_session.before)
 
-#         assert result == f"minishell: {test_file}: Permission denied"
-#     finally:
-#         if os.path.exists(test_file):
-#             os.remove(test_file)
+            assert result == f"minishell: {test_file}: Permission denied"
+    finally:
+        if os.path.exists(test_file):
+            os.remove(test_file)
 
 
 def test_error_permission_input_redirection(shell_session):
@@ -334,15 +335,14 @@ def test_error_only_redirection_ambiguous(shell_session):
     assert result == "minishell: ***: ambiguous redirect"
 
 
-# TODO: Comment out after export is fixed
-# def test_error_ambiguous_redirection_ifs(shell_session):
-#     shell_session.sendline("export FILES='a b c'")
-#     shell_session.sendline("echo Hello > $FILES")
-#     shell_session.expect(PROMPT)
+def test_error_ambiguous_redirection_ifs(shell_session):
+    shell_session.sendline("export FILES='a b c'")
+    shell_session.expect(PROMPT)
+    shell_session.sendline("echo Hello > $FILES")
+    shell_session.expect(PROMPT)
 
-
-#     result = get_command_output(shell_session.before)
-#     assert result == "minishell: $FILES: ambiguous redirect"
+    result = get_command_output(shell_session.before)
+    assert result == "minishell: $FILES: ambiguous redirect"
 
 
 def test_subshell_output_redirection(shell_session):


### PR DESCRIPTION
fix #186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test file names for better clarity and maintainability in redirection tests, ensuring they more accurately reflect the specific scenarios being tested.
	- Restored and enabled the `test_warning_heredoc` function to the test suite.
	- Enhanced GitHub Actions workflow for improved build times with parallel execution.
- **Bug Fixes**
	- Updated expected output strings in heredoc tests to reflect changes in the environment variable.
- **New Features**
	- Added new assertions to check exit statuses of commands in simple command execution tests.
	- Introduced a new test for behavior when the `PATH` environment variable is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->