### PR TITLE
194 fix memory leak in child process

### DIFF
--- a/include/env.h
+++ b/include/env.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.h                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
+/*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/08 12:35:50 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/25 13:07:22 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/26 18:17:33 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,6 @@ char			*get_env_value(t_env_list *env);
 t_env_list		*init_env(char **envp);
 t_env_list		*lookup_env(char *key, t_env_list *env);
 char			*lookup_value(const char *key, t_env_list *env_list);
-const char		*return_entire_path(const char *basename, t_env_list *env_list);
 void			set_env_is_valid_value(t_env_list *env, bool is_valid_value);
 void			set_env_value(t_env_list *env, char *value);
 void			update_env_value(t_env_list *env, char *value);

--- a/include/env.h
+++ b/include/env.h
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/08 12:35:50 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/26 18:17:33 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/26 18:18:36 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ t_env_list		*construct_env(char *name, char *value);
 t_env_list		*construct_env_with_bool(char *key, char *value,
 					bool is_valid_value);
 t_env_list		*convert_array_to_env(char **envp);
-const char		**convert_env_to_array(t_env_list *env_list);
+char			**convert_env_to_array(t_env_list *env_list);
 void			destroy_env(t_env_list *env);
 void			destroy_env_helper(void *content);
 void			destroy_env_list(t_env_list *env_list);

--- a/src/env/convert_env_to_array.c
+++ b/src/env/convert_env_to_array.c
@@ -6,17 +6,17 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/09 21:32:41 by yliu              #+#    #+#             */
-/*   Updated: 2024/10/26 18:06:49 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/26 18:18:54 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "env.h"
 
-const char	**convert_env_to_array(t_env_list *env)
+char	**convert_env_to_array(t_env_list *env)
 {
-	const char	**env_array;
-	char		*tmp;
-	int			i;
+	char	**env_array;
+	char	*tmp;
+	int		i;
 
 	env_array = ft_xmalloc(sizeof(char *) * (ft_lstsize(env) + 1));
 	i = 0;

--- a/src/env/convert_env_to_array.c
+++ b/src/env/convert_env_to_array.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   convert_env_to_array.c                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yliu <yliu@student.42.jp>                  +#+  +:+       +#+        */
+/*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/09 21:32:41 by yliu              #+#    #+#             */
-/*   Updated: 2024/09/20 21:58:34 by yliu             ###   ########.fr       */
+/*   Updated: 2024/10/26 18:06:49 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,17 +15,19 @@
 const char	**convert_env_to_array(t_env_list *env)
 {
 	const char	**env_array;
-	const char	**tmp_array;
+	char		*tmp;
+	int			i;
 
 	env_array = ft_xmalloc(sizeof(char *) * (ft_lstsize(env) + 1));
-	tmp_array = env_array;
+	i = 0;
 	while (env)
 	{
-		*tmp_array = ft_xstrjoin(get_env_key(env),
-				ft_xstrjoin("=", get_env_value(env)));
+		tmp = ft_xstrjoin(get_env_key(env), "=");
+		env_array[i] = ft_xstrjoin(tmp, get_env_value(env));
+		free(tmp);
 		env = env->next;
-		tmp_array++;
+		i++;
 	}
-	*tmp_array = NULL;
+	env_array[i] = NULL;
 	return (env_array);
 }

--- a/src/exec/spawn_command.c
+++ b/src/exec/spawn_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/26 23:25:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/26 18:14:03 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/26 18:18:11 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,7 @@ static void	execute_external_command(char **argv, t_ctx *ctx)
 	}
 	if (is_a_directory(cmd_path))
 		print_error_exit(cmd_path, strerror(EISDIR), EXIT_OTHER_ERR);
-	env_array = (char **)convert_env_to_array(ctx->env);
+	env_array = convert_env_to_array(ctx->env);
 	if (execve(cmd_path, argv, env_array) == -1)
 	{
 		ft_free_strs(env_array);

--- a/src/exec/spawn_command.c
+++ b/src/exec/spawn_command.c
@@ -6,7 +6,7 @@
 /*   By: reasuke <reasuke@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/26 23:25:57 by reasuke           #+#    #+#             */
-/*   Updated: 2024/10/19 15:37:45 by reasuke          ###   ########.fr       */
+/*   Updated: 2024/10/26 18:14:03 by reasuke          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ static char	*search_for_command(char *basename, t_env_list *env_list)
 static void	execute_external_command(char **argv, t_ctx *ctx)
 {
 	char	*cmd_path;
+	char	**env_array;
 
 	cmd_path = argv[0];
 	if (lookup_value("PATH", ctx->env) && ft_strchr(cmd_path, '/') == NULL)
@@ -71,8 +72,10 @@ static void	execute_external_command(char **argv, t_ctx *ctx)
 	}
 	if (is_a_directory(cmd_path))
 		print_error_exit(cmd_path, strerror(EISDIR), EXIT_OTHER_ERR);
-	if (execve(cmd_path, argv, (char **)convert_env_to_array(ctx->env)) == -1)
+	env_array = (char **)convert_env_to_array(ctx->env);
+	if (execve(cmd_path, argv, env_array) == -1)
 	{
+		ft_free_strs(env_array);
 		if (errno == ENOENT)
 			print_error_exit(argv[0], strerror(errno), EXIT_NOT_FOUND_ERR);
 		else

--- a/tests/unit/test_env.cpp
+++ b/tests/unit/test_env.cpp
@@ -33,7 +33,7 @@ TEST(construct_env, TwoEnv) {
 
 TEST(convert_env_to_array, OneEnv) {
   t_env_list *env = construct_env(strdup("HOME"), strdup("/home/user"));
-  const char **env_array = convert_env_to_array(env);
+  char **env_array = convert_env_to_array(env);
 
   EXPECT_STREQ(env_array[0], "HOME=/home/user");
   EXPECT_EQ(env_array[1], nullptr);
@@ -45,7 +45,7 @@ TEST(convert_env_to_array, MultiEnv) {
   t_env_list *env = construct_env(strdup("HOME"), strdup("/home/user"));
   t_env_list *env2 = construct_env(strdup("PATH"), strdup("/usr/bin"));
   ft_lstadd_back(&env, env2);
-  const char **env_array = convert_env_to_array(env);
+  char **env_array = convert_env_to_array(env);
 
   EXPECT_STREQ(env_array[0], "HOME=/home/user");
   EXPECT_STREQ(env_array[1], "PATH=/usr/bin");


### PR DESCRIPTION
fix #194

- **Refactor convert_env_to_array**
- **Fix memory leak in execute_external_command**
- **Delete unnecessary prototype**
- **Fix return value of convert_env_to_array**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The function `convert_env_to_array` now returns a mutable array of environment variables, allowing for modifications.
  
- **Bug Fixes**
	- Enhanced memory management for the `env_array` during command execution, ensuring proper cleanup.

- **Tests**
	- Updated tests for `convert_env_to_array` to reflect the change in return type, ensuring continued accuracy in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->